### PR TITLE
Handle signals when asking for password

### DIFF
--- a/src/command/commands.c
+++ b/src/command/commands.c
@@ -80,6 +80,12 @@ static void _who_roster(gchar **args, struct cmd_help_t help);
 
 extern GHashTable *commands;
 
+// typedef for signal handlers
+typedef void (*sighandler)(int);
+
+void connect_sigint(int sig){}
+void connect_sigtstp(int sig){}
+
 gboolean
 cmd_connect(gchar **args, struct cmd_help_t help)
 {
@@ -131,7 +137,11 @@ cmd_connect(gchar **args, struct cmd_help_t help)
         if (account != NULL) {
             jid = account_create_full_jid(account);
             if (account->password == NULL) {
+                sighandler oldint = signal(SIGINT, connect_sigint);
+                sighandler oldtstp = signal(SIGTSTP, connect_sigtstp);
                 account->password = ui_ask_password();
+                signal(SIGINT, oldint);
+                signal(SIGTSTP, oldtstp);
             }
             cons_show("Connecting with account %s as %s", account->name, jid);
             if(g_hash_table_contains(options, "port") || g_hash_table_contains(options, "server"))
@@ -139,7 +149,11 @@ cmd_connect(gchar **args, struct cmd_help_t help)
             conn_status = jabber_connect_with_account(account);
             account_free(account);
         } else {
+            sighandler oldint = signal(SIGINT, connect_sigint);
+            sighandler oldtstp = signal(SIGTSTP, connect_sigtstp);
             char *passwd = ui_ask_password();
+            signal(SIGINT, oldint);
+            signal(SIGTSTP, oldtstp);
             jid = strdup(lower);
             cons_show("Connecting as %s", jid);
             conn_status = jabber_connect_with_details(jid, passwd, altdomain, port);

--- a/src/command/commands.c
+++ b/src/command/commands.c
@@ -80,12 +80,6 @@ static void _who_roster(gchar **args, struct cmd_help_t help);
 
 extern GHashTable *commands;
 
-// typedef for signal handlers
-typedef void (*sighandler)(int);
-
-void connect_sigint(int sig){}
-void connect_sigtstp(int sig){}
-
 gboolean
 cmd_connect(gchar **args, struct cmd_help_t help)
 {
@@ -137,11 +131,7 @@ cmd_connect(gchar **args, struct cmd_help_t help)
         if (account != NULL) {
             jid = account_create_full_jid(account);
             if (account->password == NULL) {
-                sighandler oldint = signal(SIGINT, connect_sigint);
-                sighandler oldtstp = signal(SIGTSTP, connect_sigtstp);
                 account->password = ui_ask_password();
-                signal(SIGINT, oldint);
-                signal(SIGTSTP, oldtstp);
             }
             cons_show("Connecting with account %s as %s", account->name, jid);
             if(g_hash_table_contains(options, "port") || g_hash_table_contains(options, "server"))
@@ -149,11 +139,7 @@ cmd_connect(gchar **args, struct cmd_help_t help)
             conn_status = jabber_connect_with_account(account);
             account_free(account);
         } else {
-            sighandler oldint = signal(SIGINT, connect_sigint);
-            sighandler oldtstp = signal(SIGTSTP, connect_sigtstp);
             char *passwd = ui_ask_password();
-            signal(SIGINT, oldint);
-            signal(SIGTSTP, oldtstp);
             jid = strdup(lower);
             cons_show("Connecting as %s", jid);
             conn_status = jabber_connect_with_details(jid, passwd, altdomain, port);

--- a/src/ui/core.c
+++ b/src/ui/core.c
@@ -85,6 +85,12 @@ static void _win_handle_page(const wint_t * const ch, const int result);
 static void _win_show_history(int win_index, const char * const contact);
 static void _ui_draw_term_title(void);
 
+// typedef for signal handlers
+typedef void (*sighandler)(int);
+
+void connect_sigint(int sig){}
+void connect_sigtstp(int sig){}
+
 void
 ui_init(void)
 {
@@ -2212,7 +2218,11 @@ ui_ask_password(void)
   status_bar_get_password();
   status_bar_update_virtual();
   inp_block();
+  sighandler oldint = signal(SIGINT, connect_sigint);
+  sighandler oldtstp = signal(SIGTSTP, connect_sigtstp);
   inp_get_password(passwd);
+  signal(SIGINT, oldint);
+  signal(SIGTSTP, oldtstp);
   inp_non_block();
 
   return passwd;


### PR DESCRIPTION
C-c and C-z no longer interfere with Profanity when asking for password.