### PR TITLE
Add readline-style keybindings

### DIFF
--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -423,6 +423,7 @@ _handle_edit(int result, const wint_t ch, char *input, int *size)
             if (result != KEY_CODE_YES) {
                 return 0;
             }
+        case KEY_CTRL_D:
             if (inp_x == display_size-1) {
                 gchar *start = g_utf8_substring(input, 0, inp_x);
                 for (*size = 0; *size < strlen(start); (*size)++) {
@@ -459,6 +460,7 @@ _handle_edit(int result, const wint_t ch, char *input, int *size)
             if (result != KEY_CODE_YES) {
                 return 0;
             }
+        case KEY_CTRL_B:
             if (inp_x > 0) {
                 wmove(inp_win, 0, inp_x-1);
 
@@ -474,6 +476,7 @@ _handle_edit(int result, const wint_t ch, char *input, int *size)
             if (result != KEY_CODE_YES) {
                 return 0;
             }
+        case KEY_CTRL_F:
             if (inp_x < display_size) {
                 wmove(inp_win, 0, inp_x+1);
 
@@ -489,6 +492,7 @@ _handle_edit(int result, const wint_t ch, char *input, int *size)
             if (result != KEY_CODE_YES) {
                 return 0;
             }
+        case KEY_CTRL_P:
             prev = cmd_history_previous(input, size);
             if (prev) {
                 inp_replace_input(input, prev, size);
@@ -499,6 +503,7 @@ _handle_edit(int result, const wint_t ch, char *input, int *size)
             if (result != KEY_CODE_YES) {
                 return 0;
             }
+        case KEY_CTRL_N:
             next = cmd_history_next(input, size);
             if (next) {
                 inp_replace_input(input, next, size);
@@ -513,6 +518,7 @@ _handle_edit(int result, const wint_t ch, char *input, int *size)
             if (result != KEY_CODE_YES) {
                 return 0;
             }
+        case KEY_CTRL_A:
             wmove(inp_win, 0, 0);
             pad_start = 0;
             _inp_win_update_virtual();
@@ -522,6 +528,7 @@ _handle_edit(int result, const wint_t ch, char *input, int *size)
             if (result != KEY_CODE_YES) {
                 return 0;
             }
+        case KEY_CTRL_E:
             _go_to_end(display_size);
             return 1;
 
@@ -535,10 +542,18 @@ _handle_edit(int result, const wint_t ch, char *input, int *size)
             }
             return 1;
 
-        case 23: // ctrl-w
+        case KEY_CTRL_W:
             _delete_previous_word(input, size);
             return 1;
             break;
+
+        case KEY_CTRL_U:
+            while (getcurx(inp_win) > 0) {
+                _delete_previous_word(input, size);
+            }
+            return 1;
+            break;
+
         default:
             return 0;
         }

--- a/src/ui/inputwin.h
+++ b/src/ui/inputwin.h
@@ -35,6 +35,16 @@
 #ifndef UI_INPUTWIN_H
 #define UI_INPUTWIN_H
 
+#define KEY_CTRL_A 0001
+#define KEY_CTRL_B 0002
+#define KEY_CTRL_D 0004
+#define KEY_CTRL_E 0005
+#define KEY_CTRL_F 0006
+#define KEY_CTRL_N 0016
+#define KEY_CTRL_P 0020
+#define KEY_CTRL_U 0025
+#define KEY_CTRL_W 0027
+
 void create_input_window(void);
 wint_t inp_get_char(char *input, int *size, int *result);
 void inp_win_reset(void);


### PR DESCRIPTION
This commit adds a common subset of readline style keybindings, as requested in issue #216 and issue #460, which should satisfy most users used to the Unix command line (or Unix clients like `irssi`). It implements the following new bindings:

Profanity Default | Readline Style Equivalent    | Readline Command
----------------- | ---------------------------- | -------------------
<kbd>Del</kbd>    | <kbd>Ctrl</kbd>+<kbd>D</kbd> | `delete-char`
<kbd>←</kbd>      | <kbd>Ctrl</kbd>+<kbd>B</kbd> | `backward-char`
<kbd>→</kbd>      | <kbd>Ctrl</kbd>+<kbd>F</kdb> | `forward-char`
<kbd>↑</kbd>      | <kbd>Ctrl</kbd>+<kbd>P</kdb> | `previous-history`
<kbd>↓</kbd>      | <kbd>Ctrl</kbd>+<kbd>N</kdb> | `next-history`
<kbd>Home</kbd>   | <kbd>Ctrl</kbd>+<kbd>A</kdb> | `beginning-of-line`
<kbd>End</kbd>    | <kbd>Ctrl</kbd>+<kbd>E</kdb> | `end-of-line`
                  | <kbd>Ctrl</kbd>+<kbd>U</kdb> | `unix-line-discard`

Very experienced readline users may also miss <kbd>Meta</kbd>+<kbd>B</kbd> and <kbd>Meta</kbd>+<kbd>F</kbd> for `backward-word` and `forward-word`, and <kbd>Ctrl</kbd>+<kbd>K</kbd> for `kill-line`, but, I think the above will be enough to make most Unix junkies happy.