### PR TITLE
General fixes related to eval_password

### DIFF
--- a/src/command/commands.c
+++ b/src/command/commands.c
@@ -84,7 +84,6 @@ gboolean
 cmd_connect(gchar **args, struct cmd_help_t help)
 {
     gboolean result = FALSE;
-    char *def = prefs_get_string(PREF_DEFAULT_ACCOUNT);
 
     jabber_conn_status_t conn_status = jabber_get_connection_status();
 
@@ -94,6 +93,7 @@ cmd_connect(gchar **args, struct cmd_help_t help)
     } else {
         gchar *opt_keys[] = { "server", "port", NULL };
         gboolean parsed;
+        char *def = prefs_get_string(PREF_DEFAULT_ACCOUNT);
 
         GHashTable *options = parse_options(&args[args[0] ? 1 : 0], opt_keys, &parsed);
         if (!parsed) {
@@ -124,6 +124,8 @@ cmd_connect(gchar **args, struct cmd_help_t help)
                 return TRUE;
             }
         }
+        g_free(def);
+
         char *lower = g_utf8_strdown(user, -1);
         char *jid;
 
@@ -175,8 +177,6 @@ cmd_connect(gchar **args, struct cmd_help_t help)
 
         result = TRUE;
     }
-
-    g_free(def);
 
     return result;
 }

--- a/src/command/commands.c
+++ b/src/command/commands.c
@@ -137,7 +137,7 @@ cmd_connect(gchar **args, struct cmd_help_t help)
                 if(stream){
                     // Limit to READ_BUF_SIZE bytes to prevent overflows in the case of a poorly chosen command
                     account->password = g_malloc(READ_BUF_SIZE);
-                    fgets(account->password, READ_BUF_SIZE, stream);
+                    account->password = fgets(account->password, READ_BUF_SIZE, stream);
                     pclose(stream);
                 } else {
                     log_error("popen failed when running eval_password.");

--- a/src/command/commands.c
+++ b/src/command/commands.c
@@ -137,6 +137,10 @@ cmd_connect(gchar **args, struct cmd_help_t help)
                 if(stream){
                     // Limit to READ_BUF_SIZE bytes to prevent overflows in the case of a poorly chosen command
                     account->password = g_malloc(READ_BUF_SIZE);
+                    if(!account->password){
+                        log_error("Failed to allocate enough memory to read eval_password output");
+                        return TRUE;
+                    }
                     account->password = fgets(account->password, READ_BUF_SIZE, stream);
                     pclose(stream);
                 } else {

--- a/src/config/accounts.c
+++ b/src/config/accounts.c
@@ -226,16 +226,6 @@ accounts_get_account(const char * const name)
 
         gchar *password = g_key_file_get_string(accounts, name, "password", NULL);
         gchar *eval_password = g_key_file_get_string(accounts, name, "eval_password", NULL);
-        // Evaluate as shell command to retrieve password
-        if (eval_password != NULL) {
-            FILE *stream = popen(eval_password, "r");
-            // Limit to READ_BUF_SIZE bytes to prevent overflows in the case of a poorly chosen command
-            password = g_malloc(READ_BUF_SIZE);
-            gchar *result = fgets(password, READ_BUF_SIZE, stream);
-            if (result != NULL) {
-                password = result;
-            }
-        }
         gboolean enabled = g_key_file_get_boolean(accounts, name, "enabled", NULL);
 
         gchar *server = g_key_file_get_string(accounts, name, "server", NULL);

--- a/tests/test_cmd_rooms.c
+++ b/tests/test_cmd_rooms.c
@@ -61,6 +61,7 @@ void cmd_rooms_uses_account_default_when_no_arg(void **state)
     account->name = NULL;
     account->jid = NULL;
     account->password = NULL;
+    account->eval_password = NULL;
     account->resource = NULL;
     account->server = NULL;
     account->last_presence = NULL;


### PR DESCRIPTION
* `eval_password` handling code is now in `cmd_connect`, so that the field can be changed without clearing itself.
* `pclose` is called on the `popen`ed `eval_password` command, but this is going to fail if the process never terminates. A solution would be to use `fork` instead of `popen` and manually `kill` the pid.
* `stderr` from the `popen`ed process does not make curses mad anyore.
* Added a sanity check for memory allocation of `account->password`.
* Unrelated, but moved the retrieval/freeing of the default account string to more convenient places.