### PR TITLE
Strip quote chars from name autocomplete

### DIFF
--- a/src/command/command.c
+++ b/src/command/command.c
@@ -98,6 +98,7 @@ static char * _role_autocomplete(char *input, int *size);
 static char * _resource_autocomplete(char *input, int *size);
 static char * _titlebar_autocomplete(char *input, int *size);
 static char * _inpblock_autocomplete(char *input, int *size);
+static char * _strip_quotes_from_names(char *input, int *size);
 
 GHashTable *commands = NULL;
 
@@ -1932,6 +1933,8 @@ _cmd_complete_parameters(char *input, int *size)
         if (nick_ac != NULL) {
             gchar *nick_choices[] = { "/msg", "/info", "/caps", "/status", "/software" } ;
 
+            // Remove quote character before and after names when doing autocomplete
+            input = _strip_quotes_from_names(input, size);
             for (i = 0; i < ARRAY_SIZE(nick_choices); i++) {
                 result = autocomplete_param_with_ac(input, size, nick_choices[i],
                     nick_ac, TRUE);
@@ -1946,6 +1949,8 @@ _cmd_complete_parameters(char *input, int *size)
     // otherwise autocomplete using roster
     } else {
         gchar *contact_choices[] = { "/msg", "/info", "/status" };
+        // Remove quote character before and after names when doing autocomplete
+        input = _strip_quotes_from_names(input, size);
         for (i = 0; i < ARRAY_SIZE(contact_choices); i++) {
             result = autocomplete_param_with_func(input, size, contact_choices[i],
                 roster_contact_autocomplete);
@@ -2983,4 +2988,22 @@ _account_autocomplete(char *input, int *size)
 
     found = autocomplete_param_with_ac(input, size, "/account", account_ac, TRUE);
     return found;
+}
+
+static char *
+_strip_quotes_from_names(char *input, int *size) {
+    // Remove starting quote if it exists
+    if(strchr(input, '"') != NULL) {
+        if(strchr(input, ' ') + 1 == strchr(input, '"')) {
+            memmove(strchr(input, '"'), strchr(input, '"')+1, strchr(input, '\0') - strchr(input, '"'));
+        }
+    }
+
+    // Remove ending quote if it exists
+    if(strchr(input, '"') != NULL) {
+        if(strchr(input, '\0') - 1 == strchr(input, '"')) {
+            memmove(strchr(input, '"'), strchr(input, '"')+1, strchr(input, '\0') - strchr(input, '"'));
+        }
+    }
+    return input;
 }


### PR DESCRIPTION
This is to address a minor annoyance I had with autocomplete.  When I'm logged into FB all the user names show as people's full names with spaces.  When you autocomplete it adds quote characters around a person's name.  However, if you for instance autocomplete then realize that your /msg "Firstname Lastname" has the right first name but wrong last name and you backspace the lastname then the autocomplete will fail when you hit tab again.  This is because the first quote characterbefore Firstname is being used to match against the autocomplete.

This diff strips out beginning and ending quote characters before doing autocomplete.  I chose to do it at this point in the code because it will only impact the user interaction functions (/msg etc) which is really the only area I know of where it would be helpful.

Also, I haven't tested this in a chat room command.c:1953 because I couldn't find a public one with users in the room (tried a few).

Tests pass.  Let me know if I should add more.  Wasn't sure if there were any good ones that could be added.