### PR TITLE
Bind ^D to /quit in main window and to /close in other windows

### DIFF
--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -397,6 +397,13 @@ _inp_rl_linehandler(char *line)
         if (!get_password) {
             add_history(line);
         }
+    } else if (!line) {
+        int index = ui_current_win_index();
+        if (index > 1 && ui_win_exists(index)) {
+            line = strdup("/close");
+        } else {
+            line = strdup("/quit");
+        }
     }
     inp_line = line;
 }


### PR DESCRIPTION
In a Shell, I find it convenient to use `^D` to quit the application. Adopted to profanity,
* `^D` quits the application if the main window has focus whereas
* if a chat window has focus, `^D` closes this chat window.