### PR TITLE
Add api_get_current_muc() to plugin api

### DIFF
--- a/src/plugins/api.c
+++ b/src/plugins/api.c
@@ -120,6 +120,18 @@ api_get_current_recipient(void)
     }
 }
 
+char *
+api_get_current_muc(void)
+{
+    win_type_t win_type = ui_current_win_type();
+    if (win_type == WIN_MUC) {
+        ProfMucWin *mucwin = wins_get_current_muc();
+        return mucwin->roomjid;
+    } else {
+        return NULL;
+    }
+}
+
 void
 api_log_debug(const char *message)
 {

--- a/src/plugins/api.h
+++ b/src/plugins/api.h
@@ -42,6 +42,7 @@ void api_cons_show(const char * const message);
 void api_notify(const char *message, const char *category, int timeout_ms);
 void api_send_line(char *line);
 char * api_get_current_recipient(void);
+char * api_get_current_muc(void);
 
 void api_register_command(const char *command_name, int min_args, int max_args,
     const char *usage, const char *short_help, const char *long_help,

--- a/src/plugins/c_api.c
+++ b/src/plugins/c_api.c
@@ -109,6 +109,12 @@ c_api_get_current_recipient(void)
     return api_get_current_recipient();
 }
 
+static char *
+c_api_get_current_muc(void)
+{
+    return api_get_current_muc();
+}
+
 static void
 c_api_log_debug(const char *message)
 {
@@ -218,6 +224,7 @@ c_api_init(void)
     prof_notify = c_api_notify;
     prof_send_line = c_api_send_line;
     prof_get_current_recipient = c_api_get_current_recipient;
+    prof_get_current_muc = c_api_get_current_muc;
     prof_log_debug = c_api_log_debug;
     prof_log_info = c_api_log_info;
     prof_log_warning = c_api_log_warning;

--- a/src/plugins/lua_api.c
+++ b/src/plugins/lua_api.c
@@ -161,6 +161,20 @@ lua_api_get_current_recipient(lua_State *L)
 }
 
 static int
+lua_api_get_current_muc(lua_State *L)
+{
+    const char *room = api_get_current_muc();
+
+    if (room != NULL) {
+        lua_pushstring(L, room);
+    } else {
+        lua_pushnil(L);
+    }
+
+    return 1;
+}
+
+static int
 lua_api_log_debug(lua_State *L)
 {
     const char *message = lua_tostring(L, -1);
@@ -361,6 +375,8 @@ lua_api_init(lua_State *L)
     lua_setglobal(L, "prof_notify");
     lua_pushcfunction(L, lua_api_get_current_recipient);
     lua_setglobal(L, "prof_get_current_recipient");
+    lua_pushcfunction(L, lua_api_get_current_muc);
+    lua_setglobal(L, "prof_get_current_muc");
     lua_pushcfunction(L, lua_api_log_debug);
     lua_setglobal(L, "prof_log_debug");
     lua_pushcfunction(L, lua_api_log_info);

--- a/src/plugins/profapi.c
+++ b/src/plugins/profapi.c
@@ -53,6 +53,7 @@ void (*prof_notify)(const char *message, int timeout_ms, const char *category) =
 void (*prof_send_line)(char *line) = NULL;
 
 char* (*prof_get_current_recipient)(void) = NULL;
+char* (*prof_get_current_muc)(void) = NULL;
 
 void (*prof_log_debug)(const char *message) = NULL;
 void (*prof_log_info)(const char *message) = NULL;

--- a/src/plugins/profapi.h
+++ b/src/plugins/profapi.h
@@ -53,6 +53,7 @@ void (*prof_notify)(const char *message, int timeout_ms, const char *category);
 void (*prof_send_line)(char *line);
 
 char* (*prof_get_current_recipient)(void);
+char* (*prof_get_current_muc)(void);
 
 void (*prof_log_debug)(const char *message);
 void (*prof_log_info)(const char *message);

--- a/src/plugins/python_api.c
+++ b/src/plugins/python_api.c
@@ -167,6 +167,17 @@ python_api_get_current_recipient(PyObject *self, PyObject *args)
 }
 
 static PyObject *
+python_api_get_current_muc(PyObject *self, PyObject *args)
+{
+    char *room = api_get_current_muc();
+    if (room != NULL) {
+        return Py_BuildValue("s", room);
+    } else {
+        return Py_BuildValue("");
+    }
+}
+
+static PyObject *
 python_api_log_debug(PyObject *self, PyObject *args)
 {
     const char *message = NULL;
@@ -401,6 +412,7 @@ static PyMethodDef apiMethods[] = {
     { "send_line", python_api_send_line, METH_VARARGS, "Send a line of input." },
     { "notify", python_api_notify, METH_VARARGS, "Send desktop notification." },
     { "get_current_recipient", python_api_get_current_recipient, METH_VARARGS, "Return the jid of the recipient of the current window." },
+    { "get_current_muc", python_api_get_current_muc, METH_VARARGS, "Return the jid of the room of the current window." },
     { "log_debug", python_api_log_debug, METH_VARARGS, "Log a debug message" },
     { "log_info", python_api_log_info, METH_VARARGS, "Log an info message" },
     { "log_warning", python_api_log_warning, METH_VARARGS, "Log a warning message" },

--- a/src/plugins/ruby_api.c
+++ b/src/plugins/ruby_api.c
@@ -142,6 +142,17 @@ ruby_api_get_current_recipient(VALUE self)
 }
 
 static VALUE
+ruby_api_get_current_muc(VALUE self)
+{
+    char *room = api_get_current_muc();
+    if (room != NULL) {
+        return rb_str_new2(room);
+    } else {
+        return Qnil;
+    }
+}
+
+static VALUE
 ruby_api_log_debug(VALUE self, VALUE v_message)
 {
     char *message = STR2CSTR(v_message);
@@ -324,6 +335,7 @@ ruby_api_init(void)
     rb_define_module_function(prof_module, "send_line", RUBY_METHOD_FUNC(ruby_api_send_line), 1);
     rb_define_module_function(prof_module, "notify", RUBY_METHOD_FUNC(ruby_api_notify), 3);
     rb_define_module_function(prof_module, "get_current_recipient", RUBY_METHOD_FUNC(ruby_api_get_current_recipient), 0);
+    rb_define_module_function(prof_module, "get_current_muc", RUBY_METHOD_FUNC(ruby_api_get_current_muc), 0);
     rb_define_module_function(prof_module, "log_debug", RUBY_METHOD_FUNC(ruby_api_log_debug), 1);
     rb_define_module_function(prof_module, "log_info", RUBY_METHOD_FUNC(ruby_api_log_info), 1);
     rb_define_module_function(prof_module, "log_warning", RUBY_METHOD_FUNC(ruby_api_log_warning), 1);


### PR DESCRIPTION
I added the api_get_current_muc function to use the /browser plugin in a muc : https://github.com/olivierlemoal/profanity-plugins/commit/a6dbc7a9128449b31e8c8b82df6d834151e71c43
Please let me know your thoughts on this.
