### PR TITLE
Added window auto tidy.

### DIFF
--- a/src/command/commands.c
+++ b/src/command/commands.c
@@ -727,6 +727,10 @@ cmd_winstidy(gchar **args, struct cmd_help_t help)
 {
     gboolean result = _cmd_set_boolean_preference(args[0], help, "Wins Auto Tidy", PREF_WINS_AUTO_TIDY);
 
+    if( result ) {
+        ui_tidy_wins();
+    }
+
     return result;
 }
 

--- a/src/config/theme.c
+++ b/src/config/theme.c
@@ -428,6 +428,7 @@ _load_preferences(void)
     _set_boolean_preference("flash", PREF_FLASH);
     _set_boolean_preference("splash", PREF_SPLASH);
     _set_boolean_preference("wrap", PREF_WRAP);
+    _set_boolean_preference("wins.autotidy", PREF_WINS_AUTO_TIDY);
     _set_string_preference("time", PREF_TIME);
     _set_string_preference("time.statusbar", PREF_TIME_STATUSBAR);
 


### PR DESCRIPTION
Adds the command /winstidy which is a boolean option enabled by default. 
When a window is closed it will perform a window tidy command, removing gaps from the window list.

Re: Issue #551 