### PR TITLE
Added handler for libgcrypt's logs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,7 +226,7 @@ fi
 
 AM_COND_IF([BUILD_OTR],
     [AC_CHECK_LIB([gcrypt], [gcry_set_log_handler],
-        [AC_CHECK_HEADERS([gcrypt.h], [],
+        [AC_CHECK_HEADERS([gcrypt.h], [LIBS="-lgcrypt $LIBS"],
             [grypt.h not found. Try to install libgcrypt-devel package])],
         [libgcrypt not found])],
     [])

--- a/configure.ac
+++ b/configure.ac
@@ -224,6 +224,13 @@ if test "x$enable_otr" != xno; then
             [AC_MSG_NOTICE([libotr not found, otr encryption support not enabled])])])
 fi
 
+AM_COND_IF([BUILD_OTR],
+    [AC_CHECK_LIB([gcrypt], [gcry_set_log_handler],
+        [AC_CHECK_HEADERS([gcrypt.h], [],
+            [grypt.h not found. Try to install libgcrypt-devel package])],
+        [libgcrypt not found])],
+    [])
+
 AS_IF([test "x$with_themes" = xno],
     [THEMES_INSTALL="false"],
     [THEMES_INSTALL="true"])

--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -36,6 +36,7 @@
 #include <libotr/privkey.h>
 #include <libotr/message.h>
 #include <libotr/sm.h>
+#include <gcrypt.h>
 #include <glib.h>
 
 #include "otr/otr.h"
@@ -157,10 +158,48 @@ otr_start_query(void)
     return otrlib_start_query();
 }
 
+static log_level_t
+_gcry_log_level_get(int level)
+{
+    log_level_t prof_level = PROF_LEVEL_DEBUG;
+
+    switch (level) {
+    case GCRY_LOG_DEBUG:
+        prof_level = PROF_LEVEL_DEBUG; break;
+    case GCRY_LOG_INFO:
+        prof_level = PROF_LEVEL_INFO; break;
+    case GCRY_LOG_WARN:
+        prof_level = PROF_LEVEL_WARN; break;
+    case GCRY_LOG_ERROR:
+    case GCRY_LOG_FATAL:
+    case GCRY_LOG_BUG:
+        prof_level = PROF_LEVEL_ERROR; break;
+    }
+
+    return prof_level;
+}
+
+static void
+_gcry_log_handler(void *data, int level, const char *fmt, va_list arg_ptr)
+{
+    GString *fmt_msg = g_string_new(NULL);
+    char *tail;
+
+    g_string_vprintf(fmt_msg, fmt, arg_ptr);
+    /* remove trailing \n if exists */
+    tail = &fmt_msg->str[fmt_msg->len - strlen("\n")];
+    if (strcmp("\n", tail) == 0)
+        *tail = '\0';
+    log_msg(_gcry_log_level_get(level), "gcry", fmt_msg->str);
+    g_string_free(fmt_msg, TRUE);
+}
+
 void
 otr_init(void)
 {
     log_info("Initialising OTR");
+    /* Make libgcrypt print log messages to the log file instead of stderr. */
+    gcry_set_log_handler(&_gcry_log_handler, NULL);
     OTRL_INIT;
 
     jid = NULL;


### PR DESCRIPTION
This patch fixes #562 by hiding messages to log file.