### PR TITLE
Call prefs_close() after log_close()

### DIFF
--- a/src/profanity.c
+++ b/src/profanity.c
@@ -280,11 +280,11 @@ _shutdown(void)
     p_gpg_close();
 #endif
     chat_log_close();
-    prefs_close();
     theme_close();
     accounts_close();
     cmd_uninit();
     log_close();
+    prefs_close();
 }
 
 static void


### PR DESCRIPTION
log_msg() uses prefs, so prefs_close() should be called after log_close(). It makes possible to use logs in other finalisation functions.