### PR TITLE
PGP: Fixed compilation error when libotr is not supported

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -254,9 +254,8 @@ sv_ev_incoming_message(char *barejid, char *resource, char *message, char *enc_m
 // OTR unsupported, PGP supported
 #ifndef HAVE_LIBOTR
 #ifdef HAVE_LIBGPGME
-    prof_enc_t enc_mode = chatwin->enc_mode;
     if (enc_message) {
-        char *decrypted = p_gpg_decrypt(jid->barejid, enc_message);
+        char *decrypted = p_gpg_decrypt(barejid, enc_message);
         if (decrypted) {
             ui_incoming_msg(chatwin, resource, decrypted, NULL, new_win);
             chat_log_pgp_msg_in(barejid, decrypted);


### PR DESCRIPTION
```
src/event/server_events.c: In function ‘sv_ev_incoming_message’:
src/event/server_events.c:259:41: error: ‘jid’ undeclared (first use in this function)
src/event/server_events.c:259:41: note: each undeclared identifier is reported only once for each function it appears in
src/event/server_events.c:257:16: error: unused variable ‘enc_mode’ [-Werror=unused-variable]
```

Recreate:
```
./configure --disable-otr --enable-pgp
make
```