### PR TITLE
Add no-copy and no-store hints to OTR messages

### DIFF
--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -213,6 +213,8 @@ message_send_chat_otr(const char * const barejid, const char * const msg)
     }
 
     stanza_attach_carbons_private(ctx, message);
+    stanza_attach_hints_no_copy(ctx, message);
+    stanza_attach_hints_no_store(ctx, message);
 
     if (prefs_get_boolean(PREF_RECEIPTS_REQUEST)) {
         stanza_attach_receipt_request(ctx, message);

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -306,6 +306,30 @@ stanza_attach_carbons_private(xmpp_ctx_t *ctx, xmpp_stanza_t *stanza)
 }
 
 xmpp_stanza_t *
+stanza_attach_hints_no_copy(xmpp_ctx_t *ctx, xmpp_stanza_t *stanza)
+{
+    xmpp_stanza_t *no_copy = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_name(no_copy, "no-copy");
+    xmpp_stanza_set_ns(no_copy, STANZA_NS_HINTS);
+    xmpp_stanza_add_child(stanza, no_copy);
+    xmpp_stanza_release(no_copy);
+
+    return stanza;
+}
+
+xmpp_stanza_t *
+stanza_attach_hints_no_store(xmpp_ctx_t *ctx, xmpp_stanza_t *stanza)
+{
+    xmpp_stanza_t *no_store = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_name(no_store, "no-store");
+    xmpp_stanza_set_ns(no_store, STANZA_NS_HINTS);
+    xmpp_stanza_add_child(stanza, no_store);
+    xmpp_stanza_release(no_store);
+
+    return stanza;
+}
+
+xmpp_stanza_t *
 stanza_attach_receipt_request(xmpp_ctx_t *ctx, xmpp_stanza_t *stanza)
 {
     xmpp_stanza_t *receipet_request = xmpp_stanza_new(ctx);

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -158,6 +158,7 @@
 #define STANZA_NS_CAPTCHA "urn:xmpp:captcha"
 #define STANZA_NS_PUBSUB "http://jabber.org/protocol/pubsub"
 #define STANZA_NS_CARBONS "urn:xmpp:carbons:2"
+#define STANZA_NS_HINTS "urn:xmpp:hints"
 #define STANZA_NS_FORWARD "urn:xmpp:forward:0"
 #define STANZA_NS_RECEIPTS "urn:xmpp:receipts"
 #define STANZA_NS_SIGNED "jabber:x:signed"
@@ -195,6 +196,8 @@ xmpp_stanza_t* stanza_create_chat_state(xmpp_ctx_t *ctx,
 
 xmpp_stanza_t * stanza_attach_state(xmpp_ctx_t *ctx, xmpp_stanza_t *stanza, const char * const state);
 xmpp_stanza_t * stanza_attach_carbons_private(xmpp_ctx_t *ctx, xmpp_stanza_t *stanza);
+xmpp_stanza_t * stanza_attach_hints_no_copy(xmpp_ctx_t *ctx, xmpp_stanza_t *stanza);
+xmpp_stanza_t * stanza_attach_hints_no_store(xmpp_ctx_t *ctx, xmpp_stanza_t *stanza);
 xmpp_stanza_t * stanza_attach_receipt_request(xmpp_ctx_t *ctx, xmpp_stanza_t *stanza);
 
 xmpp_stanza_t* stanza_create_message(xmpp_ctx_t *ctx, char *id,


### PR DESCRIPTION
This adds the `no-copy` and `no-store` message processing hints to OTR messages as per [XEP-0334](https://xmpp.org/extensions/xep-0334.html).

While the `no-copy` hint effectively does the same thing as the Carbons `private` hint, some clients choose to respect one but not the other.

The `no-store` hint ensures that OTR messages (which are perfect forward secret and can't be read later) are not stored in archives such as the MAM archive.