### PR TITLE
Have the installer on cygwin check for an existing installation of apt-cyg

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -63,12 +63,7 @@ cygwin_prepare()
     echo Profanity installer... installing dependencies
     echo
 
-    wget https://raw.githubusercontent.com/transcode-open/apt-cyg/master/apt-cyg
-    #wget --no-check-certificate https://raw.github.com/boothj5/apt-cyg/master/apt-cyg
-    #wget http://apt-cyg.googlecode.com/svn/trunk/apt-cyg
-    chmod +x apt-cyg
-    mv apt-cyg /usr/local/bin/
-
+    if ! command -v apt-cyg &>/dev/null; then cyg_install_apt_cyg; fi
     if [ -n "$CYG_MIRROR" ]; then
         apt-cyg -m $CYG_MIRROR install git make gcc-core m4 automake autoconf pkg-config openssl-devel libexpat-devel zlib-devel libncursesw-devel libglib2.0-devel libcurl-devel libidn-devel libssh2-devel libkrb5-devel openldap-devel libgcrypt-devel libreadline-devel libgpgme-devel libtool libuuid-devel
     else
@@ -105,6 +100,18 @@ install_profanity()
     sudo make install
 }
 
+cyg_install_apt_cyg()
+{
+    echo
+    echo Profanity installer... installing apt-cyg
+    echo
+    wget https://raw.githubusercontent.com/transcode-open/apt-cyg/master/apt-cyg
+    #wget --no-check-certificate https://raw.github.com/boothj5/apt-cyg/master/apt-cyg
+    #wget http://apt-cyg.googlecode.com/svn/trunk/apt-cyg
+    chmod +x apt-cyg
+    mv apt-cyg /usr/local/bin/
+
+}
 cyg_install_lib_mesode()
 {
     echo


### PR DESCRIPTION
The install-all.sh script doesn't check for an existing installation of the [apt-cyg](https://github.com/transcode-open/apt-cyg) script before downloading and installing it into /usr/local/bin/. As the readme of that script recommends installing it into /bin/ this can lead to redundant installation of multiple, potentially different versions of the script.

This patch adds a check for an existing installation of apt-cyg and extracts the installation method into a function.