### PR TITLE
dereferencing pointers

### DIFF
--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -203,7 +203,6 @@ prefs_free_string(char *pref)
     if (pref) {
         g_free(pref);
     }
-    pref = NULL;
 }
 
 

--- a/src/muc.c
+++ b/src/muc.c
@@ -976,6 +976,5 @@ _occupant_free(Occupant *occupant)
         free(occupant->jid);
         free(occupant->status);
         free(occupant);
-        occupant = NULL;
     }
 }

--- a/src/ui/buffer.c
+++ b/src/ui/buffer.c
@@ -76,7 +76,6 @@ buffer_free(ProfBuff buffer)
 {
     g_slist_free_full(buffer->entries, (GDestroyNotify)_free_entry);
     free(buffer);
-    buffer = NULL;
 }
 
 void


### PR DESCRIPTION
In two cleanup/free function the pointer got set to NULL so one can later check whether it got freed or not. However this change didn't have any effect outside of the function.
This dereferences it hopefully correctly.

Please review.