### PR TITLE
Get rid of compiler warning concerning NULL pointer

### DIFF
--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -299,7 +299,7 @@ static int
 _inp_printable(const wint_t ch)
 {
     char bytes[MB_CUR_MAX+1];
-    size_t utf_len = wcrtomb(bytes, ch, NULL);
+    size_t utf_len = wcrtomb(bytes, ch, (mbstate_t*)NULL);
     bytes[utf_len] = '\0';
     gunichar unichar = g_utf8_get_char(bytes);
 


### PR DESCRIPTION
Casting the into correct type.