### PR TITLE
Use g_free for Freeing the Message Section

### DIFF
--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -380,7 +380,7 @@ _mucwin_print_mention(ProfWin *window, const char *const message, const char *co
         win_print(window, '-', 0, NULL, NO_DATE | NO_ME, THEME_ROOMMENTION_TERM, "", mention_section);
     }
 
-    free(mention_section);
+    g_free(mention_section);
     g_free(mynick_lower);
     g_free(message_lower);
 }


### PR DESCRIPTION
Using `g_free` in the `_mucwin_print_mention` function fixes the implicit declaration error.

Related issue: #743