### PR TITLE
libotr upgrade on Fedora

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -34,7 +34,7 @@ fedora_prepare()
     echo Profanity installer... installing dependencies
     echo
 
-    sudo dnf -y install gcc git autoconf automake openssl-devel expat-devel ncurses-devel glib2-devel libnotify-devel libcurl-devel libXScrnSaver-devel libotr3-devel readline-devel libtool gpgme-devel
+    sudo dnf -y install gcc git autoconf automake openssl-devel expat-devel ncurses-devel glib2-devel libnotify-devel libcurl-devel libXScrnSaver-devel libotr-devel readline-devel libtool gpgme-devel
 }
 
 opensuse_prepare()


### PR DESCRIPTION
So libotr released a patch (libotr 4.1.1) for a interger overflow vulnerability. [0] I was surprised to find profanity was still using a vulnerable version of libotr, turns out the reason libotr version 3.x is forced in the Fedora install. 

This patch fixes that. Tested on Fedora 23 x86_64. I checked the dependencies for other distros, they do not appear to need to be changed. Not sure about cygwin.

[0] https://lists.cypherpunks.ca/pipermail/otr-users/2016-March/002581.html