### PR TITLE
Disable python-plugins by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,12 @@ AC_ARG_WITH([themes],
 # python
 if test "x$enable_plugins" = xno; then
     AM_CONDITIONAL([BUILD_PYTHON_API], [false])
-elif test "x$enable_python_plugins" != xno; then
+#
+# Python plugins are temporary disabled by default, because Profanity doesn't
+# build with all python versions. Change `= xyes` to `!= xno` to enable it by
+# default.
+#
+elif test "x$enable_python_plugins" = xyes; then
     AS_IF([test "x$PLATFORM" = xosx], [
         AS_IF([test "x$PYTHON_FRAMEWORK" = x], [ PYTHON_FRAMEWORK="/Library/Frameworks/Python.framework" ])
         AC_MSG_NOTICE([Symlinking Python.framework to $PYTHON_FRAMEWORK])


### PR DESCRIPTION
Profanity fails to build with multiple errors on my system with python-3.5:
```
src/plugins/python_plugins.c: In function ‘python_env_init’:
src/plugins/python_plugins.c:65:34: error: passing argument 1 of ‘g_string_new’ from incompatible pointer type [-Werror]
     GString *path = g_string_new(Py_GetPath());

src/plugins/python_plugins.c: In function ‘python_pre_chat_message_display_hook’:
src/plugins/python_plugins.c:245:17: error: implicit declaration of function ‘PyString_AsString’ [-Werror=implicit-function-declaration]
                 char *result_str = strdup(PyString_AsString(PyUnicode_AsUTF8String(result)));

(many similar errors)
```
This can confuse a user who wants to try Profanity and just build it with `configure && make`.

This patch is just possible quick workaround for the problem.