### PR TITLE
Use autoconf config.h for GPGME _FILE_OFFSET_BITS

### DIFF
--- a/src/pgp/gpg.c
+++ b/src/pgp/gpg.c
@@ -33,6 +33,7 @@
  */
 
 #include "prof_config.h"
+#include "config.h"
 
 #include <locale.h>
 #include <string.h>


### PR DESCRIPTION
fixes #779