### PR TITLE
Define stanza's attributes as const char*

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -508,7 +508,7 @@ sv_ev_incoming_carbon(char *barejid, char *resource, char *message, char *pgp_me
 }
 
 void
-sv_ev_message_receipt(char *barejid, char *id)
+sv_ev_message_receipt(const char *const barejid, const char *const id)
 {
     ProfChatWin *chatwin = wins_get_chat(barejid);
     if (!chatwin)

--- a/src/event/server_events.h
+++ b/src/event/server_events.h
@@ -58,7 +58,7 @@ void sv_ev_inactive(char *barejid, char *resource);
 void sv_ev_activity(char *barejid, char *resource, gboolean send_states);
 void sv_ev_gone(const char *const barejid, const char *const resource);
 void sv_ev_subscription(const char *from, jabber_subscr_t type);
-void sv_ev_message_receipt(char *barejid, char *id);
+void sv_ev_message_receipt(const char *const barejid, const char *const id);
 void sv_ev_contact_offline(char *contact, char *resource, char *status);
 void sv_ev_contact_online(char *contact, Resource *resource, GDateTime *last_activity, char *pgpkey);
 void sv_ev_leave_room(const char *const room);

--- a/src/muc.c
+++ b/src/muc.c
@@ -723,7 +723,7 @@ muc_jid_autocomplete_add_all(const char *const room, GSList *jids)
         if (chat_room->jid_ac) {
             GSList *curr_jid = jids;
             while (curr_jid) {
-                char *jid = curr_jid->data;
+                const char *jid = curr_jid->data;
                 Jid *jidp = jid_create(jid);
                 if (jidp) {
                     if (jidp->barejid) {

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -607,7 +607,7 @@ mucwin_handle_affiliation_list(ProfMucWin *mucwin, const char *const affiliation
         win_vprint(window, '!', 0, NULL, 0, 0, "", "Affiliation: %s", affiliation);
         GSList *curr_jid = jids;
         while (curr_jid) {
-            char *jid = curr_jid->data;
+            const char *jid = curr_jid->data;
             win_vprint(window, '!', 0, NULL, 0, 0, "", "  %s", jid);
             curr_jid = g_slist_next(curr_jid);
         }
@@ -699,7 +699,7 @@ mucwin_handle_role_list(ProfMucWin *mucwin, const char *const role, GSList *nick
         win_vprint(window, '!', 0, NULL, 0, 0, "", "Role: %s", role);
         GSList *curr_nick = nicks;
         while (curr_nick) {
-            char *nick = curr_nick->data;
+            const char *nick = curr_nick->data;
             Occupant *occupant = muc_roster_item(mucwin->roomjid, nick);
             if (occupant) {
                 if (occupant->jid) {

--- a/src/xmpp/bookmark.c
+++ b/src/xmpp/bookmark.c
@@ -245,11 +245,12 @@ _bookmark_result_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
     xmpp_ctx_t *ctx = connection_get_ctx();
     char *id = (char *)userdata;
     xmpp_stanza_t *ptr;
-    xmpp_stanza_t *nick;
+    xmpp_stanza_t *nick_st;
     xmpp_stanza_t *password_st;
-    char *name;
-    char *jid;
-    char *autojoin;
+    const char *name;
+    const char *jid;
+    const char *autojoin;
+    char *nick;
     char *password;
     gboolean autojoin_val;
     Jid *my_jid;
@@ -291,13 +292,13 @@ _bookmark_result_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
 
         log_debug("Handle bookmark for %s", jid);
 
-        name = NULL;
-        nick = xmpp_stanza_get_child_by_name(ptr, "nick");
-        if (nick) {
+        nick = NULL;
+        nick_st = xmpp_stanza_get_child_by_name(ptr, "nick");
+        if (nick_st) {
             char *tmp;
-            tmp = xmpp_stanza_get_text(nick);
+            tmp = xmpp_stanza_get_text(nick_st);
             if (tmp) {
-                name = strdup(tmp);
+                nick = strdup(tmp);
                 xmpp_free(ctx, tmp);
             }
         }
@@ -323,7 +324,7 @@ _bookmark_result_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
         autocomplete_add(bookmark_ac, jid);
         item = malloc(sizeof(*item));
         item->jid = strdup(jid);
-        item->nick = name;
+        item->nick = nick;
         item->password = password;
         item->autojoin = autojoin_val;
         bookmark_list = g_list_append(bookmark_list, item);
@@ -333,15 +334,15 @@ _bookmark_result_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
 
             char *account_name = jabber_get_account_name();
             ProfAccount *account = accounts_get_account(account_name);
-            if (name == NULL) {
-                name = account->muc_nick;
+            if (nick == NULL) {
+                nick = account->muc_nick;
             }
 
-            log_debug("Autojoin %s with nick=%s", jid, name);
-            room_jid = jid_create_from_bare_and_resource(jid, name);
+            log_debug("Autojoin %s with nick=%s", jid, nick);
+            room_jid = jid_create_from_bare_and_resource(jid, nick);
             if (!muc_active(room_jid->barejid)) {
-                presence_join_room(jid, name, password);
-                muc_join(jid, name, password, TRUE);
+                presence_join_room(jid, nick, password);
+                muc_join(jid, nick, password, TRUE);
             }
             jid_destroy(room_jid);
             account_free(account);

--- a/src/xmpp/capabilities.c
+++ b/src/xmpp/capabilities.c
@@ -283,11 +283,11 @@ _caps_copy(Capabilities *caps)
 char*
 caps_create_sha1_str(xmpp_stanza_t *const query)
 {
-    char *category = NULL;
-    char *type = NULL;
-    char *lang = NULL;
-    char *name = NULL;
-    char *feature_str = NULL;
+    const char *category = NULL;
+    const char *type = NULL;
+    const char *lang = NULL;
+    const char *name = NULL;
+    const char *feature_str = NULL;
     GSList *identities = NULL;
     GSList *features = NULL;
     GSList *form_names = NULL;
@@ -391,9 +391,9 @@ caps_create_sha1_str(xmpp_stanza_t *const query)
 Capabilities*
 caps_create(xmpp_stanza_t *query)
 {
-    char *category = NULL;
-    char *type = NULL;
-    char *name = NULL;
+    const char *category = NULL;
+    const char *type = NULL;
+    const char *name = NULL;
     char *software = NULL;
     char *software_version = NULL;
     char *os = NULL;
@@ -448,7 +448,7 @@ caps_create(xmpp_stanza_t *query)
     GSList *curr_identity = identity_stanzas;
     while (curr_identity) {
         xmpp_stanza_t *id_stanza = curr_identity->data;
-        char *stanza_lang = xmpp_stanza_get_attribute(id_stanza, "xml:lang");
+        const char *stanza_lang = xmpp_stanza_get_attribute(id_stanza, "xml:lang");
         if (stanza_lang) {
             int i = 0;
             for (i = 0; i < num_langs; i++) {
@@ -469,7 +469,7 @@ caps_create(xmpp_stanza_t *query)
         curr_identity = identity_stanzas;
         while (curr_identity) {
             xmpp_stanza_t *id_stanza = curr_identity->data;
-            char *stanza_lang = xmpp_stanza_get_attribute(id_stanza, "xml:lang");
+            const char *stanza_lang = xmpp_stanza_get_attribute(id_stanza, "xml:lang");
             if (!stanza_lang) {
                 found = id_stanza;
                 break;

--- a/src/xmpp/form.c
+++ b/src/xmpp/form.c
@@ -54,19 +54,19 @@
 static gboolean
 _is_valid_form_element(xmpp_stanza_t *stanza)
 {
-    char *name = xmpp_stanza_get_name(stanza);
+    const char *name = xmpp_stanza_get_name(stanza);
     if (g_strcmp0(name, STANZA_NAME_X) != 0) {
         log_error("Error parsing form, root element not <x/>.");
         return FALSE;
     }
 
-    char *ns = xmpp_stanza_get_ns(stanza);
+    const char *ns = xmpp_stanza_get_ns(stanza);
     if (g_strcmp0(ns, STANZA_NS_DATA) != 0) {
         log_error("Error parsing form, namespace not %s.", STANZA_NS_DATA);
         return FALSE;
     }
 
-    char *type = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_TYPE);
+    const char *type = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_TYPE);
     if ((g_strcmp0(type, "form") != 0) &&
             (g_strcmp0(type, "submit") != 0) &&
             (g_strcmp0(type, "cancel") != 0) &&
@@ -129,7 +129,7 @@ _get_property(xmpp_stanza_t *const stanza, const char *const property)
 static char*
 _get_attr(xmpp_stanza_t *const stanza, const char *const attr)
 {
-    char *result = xmpp_stanza_get_attribute(stanza, attr);
+    const char *result = xmpp_stanza_get_attribute(stanza, attr);
     if (result) {
         return strdup(result);
     } else {
@@ -207,7 +207,7 @@ form_create(xmpp_stanza_t *const form_stanza)
     // get fields
     xmpp_stanza_t *form_child = xmpp_stanza_get_children(form_stanza);
     while (form_child) {
-        char *child_name = xmpp_stanza_get_name(form_child);
+        const char *child_name = xmpp_stanza_get_name(form_child);
         if (g_strcmp0(child_name, "field") == 0) {
             xmpp_stanza_t *field_stanza = form_child;
 

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -128,7 +128,7 @@ _iq_handler(xmpp_conn_t *const conn, xmpp_stanza_t *const stanza, void *const us
         return 1;
     }
 
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *type = xmpp_stanza_get_type(stanza);
 
     if (g_strcmp0(type, STANZA_TYPE_ERROR) == 0) {
         _error_handler(stanza);
@@ -170,7 +170,7 @@ _iq_handler(xmpp_conn_t *const conn, xmpp_stanza_t *const stanza, void *const us
         roster_result_handler(stanza);
     }
 
-    char *id = xmpp_stanza_get_id(stanza);
+    const char *id = xmpp_stanza_get_id(stanza);
     if (id) {
         ProfIdHandler *handler = g_hash_table_lookup(id_handlers, id);
         if (handler) {
@@ -274,7 +274,7 @@ iq_enable_carbons(void)
 {
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_enable_carbons(ctx);
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
 
     id_handler_add(id, _enable_carbons_id_handler, NULL);
 
@@ -287,7 +287,7 @@ iq_disable_carbons(void)
 {
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_disable_carbons(ctx);
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
 
     id_handler_add(id, _disable_carbons_id_handler, NULL);
 
@@ -497,7 +497,7 @@ iq_send_software_version(const char *const fulljid)
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_create_software_version_iq(ctx, fulljid);
 
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
     id_handler_add(id, _version_result_id_handler, strdup(fulljid));
 
     send_iq_stanza(iq);
@@ -519,7 +519,7 @@ iq_destroy_room(const char *const room_jid)
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_create_instant_room_destroy_iq(ctx, room_jid);
 
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
     id_handler_add(id, _destroy_room_result_id_handler, NULL);
 
     send_iq_stanza(iq);
@@ -532,7 +532,7 @@ iq_request_room_config_form(const char *const room_jid)
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_create_room_config_request_iq(ctx, room_jid);
 
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
     id_handler_add(id, _room_config_id_handler, NULL);
 
     send_iq_stanza(iq);
@@ -545,7 +545,7 @@ iq_submit_room_config(const char *const room, DataForm *form)
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_create_room_config_submit_iq(ctx, room, form);
 
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
     id_handler_add(id, _room_config_submit_id_handler, NULL);
 
     send_iq_stanza(iq);
@@ -567,7 +567,7 @@ iq_room_affiliation_list(const char *const room, char *affiliation)
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_create_room_affiliation_list_iq(ctx, room, affiliation);
 
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
     id_handler_add(id, _room_affiliation_list_result_id_handler, strdup(affiliation));
 
     send_iq_stanza(iq);
@@ -580,7 +580,7 @@ iq_room_kick_occupant(const char *const room, const char *const nick, const char
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_create_room_kick_iq(ctx, room, nick, reason);
 
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
     id_handler_add(id, _room_kick_result_id_handler, strdup(nick));
 
     send_iq_stanza(iq);
@@ -599,7 +599,7 @@ iq_room_affiliation_set(const char *const room, const char *const jid, char *aff
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_create_room_affiliation_set_iq(ctx, room, jid, affiliation, reason);
 
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
 
     struct privilege_set_t *affiliation_set = malloc(sizeof(struct privilege_set_t));
     affiliation_set->item = strdup(jid);
@@ -618,7 +618,7 @@ iq_room_role_set(const char *const room, const char *const nick, char *role,
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_create_room_role_set_iq(ctx, room, nick, role, reason);
 
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
 
     struct privilege_set_t *role_set = malloc(sizeof(struct privilege_set_t));
     role_set->item = strdup(nick);
@@ -636,7 +636,7 @@ iq_room_role_list(const char *const room, char *role)
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_create_room_role_list_iq(ctx, room, role);
 
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
     id_handler_add(id, _room_role_list_result_id_handler, strdup(role));
 
     send_iq_stanza(iq);
@@ -648,7 +648,7 @@ iq_send_ping(const char *const target)
 {
     xmpp_ctx_t * const ctx = connection_get_ctx();
     xmpp_stanza_t *iq = stanza_create_ping_iq(ctx, target);
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
 
     GDateTime *now = g_date_time_new_now_local();
     id_handler_add(id, _manual_pong_id_handler, now);
@@ -680,7 +680,7 @@ _caps_response_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
     const char *id = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_ID);
     xmpp_stanza_t *query = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_QUERY);
 
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *type = xmpp_stanza_get_type(stanza);
     // ignore non result
     if ((g_strcmp0(type, "get") == 0) || (g_strcmp0(type, "set") == 0)) {
         return 1;
@@ -711,7 +711,7 @@ _caps_response_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
         return 0;
     }
 
-    char *node = xmpp_stanza_get_attribute(query, STANZA_ATTR_NODE);
+    const char *node = xmpp_stanza_get_attribute(query, STANZA_ATTR_NODE);
     if (node == NULL) {
         log_info("No node attribute found");
         return 0;
@@ -754,7 +754,7 @@ _caps_response_for_jid_id_handler(xmpp_stanza_t *const stanza, void *const userd
     const char *id = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_ID);
     xmpp_stanza_t *query = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_QUERY);
 
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *type = xmpp_stanza_get_type(stanza);
     // ignore non result
     if ((g_strcmp0(type, "get") == 0) || (g_strcmp0(type, "set") == 0)) {
         free(jid);
@@ -789,7 +789,7 @@ _caps_response_for_jid_id_handler(xmpp_stanza_t *const stanza, void *const userd
         return 0;
     }
 
-    char *node = xmpp_stanza_get_attribute(query, STANZA_ATTR_NODE);
+    const char *node = xmpp_stanza_get_attribute(query, STANZA_ATTR_NODE);
     if (node == NULL) {
         log_info("No node attribute found");
         free(jid);
@@ -812,7 +812,7 @@ _caps_response_legacy_id_handler(xmpp_stanza_t *const stanza, void *const userda
     xmpp_stanza_t *query = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_QUERY);
     char *expected_node = (char *)userdata;
 
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *type = xmpp_stanza_get_type(stanza);
     // ignore non result
     if ((g_strcmp0(type, "get") == 0) || (g_strcmp0(type, "set") == 0)) {
         free(expected_node);
@@ -847,7 +847,7 @@ _caps_response_legacy_id_handler(xmpp_stanza_t *const stanza, void *const userda
         return 0;
     }
 
-    char *node = xmpp_stanza_get_attribute(query, STANZA_ATTR_NODE);
+    const char *node = xmpp_stanza_get_attribute(query, STANZA_ATTR_NODE);
     if (node == NULL) {
         log_info("No node attribute found");
         free(expected_node);
@@ -880,7 +880,7 @@ _caps_response_legacy_id_handler(xmpp_stanza_t *const stanza, void *const userda
 static int
 _enable_carbons_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
 {
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *type = xmpp_stanza_get_type(stanza);
     if (g_strcmp0(type, "error") == 0) {
         char *error_message = stanza_get_error_message(stanza);
         cons_show_error("Server error enabling message carbons: %s", error_message);
@@ -896,7 +896,7 @@ _enable_carbons_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
 static int
 _disable_carbons_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
 {
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *type = xmpp_stanza_get_type(stanza);
     if (g_strcmp0(type, "error") == 0) {
         char *error_message = stanza_get_error_message(stanza);
         cons_show_error("Server error disabling message carbons: %s", error_message);
@@ -912,8 +912,8 @@ _disable_carbons_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
 static int
 _manual_pong_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
 {
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *type = xmpp_stanza_get_type(stanza);
     GDateTime *sent = (GDateTime *)userdata;
 
     // handle error responses
@@ -961,7 +961,7 @@ _autoping_timed_send(xmpp_conn_t *const conn, void *const userdata)
 
     xmpp_ctx_t *ctx = (xmpp_ctx_t *)userdata;
     xmpp_stanza_t *iq = stanza_create_ping_iq(ctx, NULL);
-    char *id = xmpp_stanza_get_id(iq);
+    const char *id = xmpp_stanza_get_id(iq);
     log_debug("Autoping: Sending ping request: %s", id);
 
     // add pong handler
@@ -987,7 +987,7 @@ _auto_pong_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
         autoping_time = NULL;
     }
 
-    char *id = xmpp_stanza_get_id(stanza);
+    const char *id = xmpp_stanza_get_id(stanza);
     if (id == NULL) {
         log_debug("Autoping: Pong handler fired.");
         return 0;
@@ -995,7 +995,7 @@ _auto_pong_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
 
     log_debug("Autoping: Pong handler fired: %s.", id);
 
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *type = xmpp_stanza_get_type(stanza);
     if (type == NULL) {
         return 0;
     }
@@ -1013,7 +1013,7 @@ _auto_pong_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
     if (error == NULL) {
         return 0;
     }
-    char *errtype = xmpp_stanza_get_type(error);
+    const char *errtype = xmpp_stanza_get_type(error);
     if (errtype == NULL) {
         return 0;
     }
@@ -1031,7 +1031,7 @@ _auto_pong_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
 static int
 _version_result_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
 {
-    char *id = xmpp_stanza_get_id(stanza);
+    const char *id = xmpp_stanza_get_id(stanza);
 
     if (id) {
         log_debug("IQ version result handler fired, id: %s.", id);
@@ -1039,8 +1039,8 @@ _version_result_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
         log_debug("IQ version result handler fired.");
     }
 
-    char *type = xmpp_stanza_get_type(stanza);
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *type = xmpp_stanza_get_type(stanza);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
 
     if (g_strcmp0(type, STANZA_TYPE_RESULT) != 0) {
         if (g_strcmp0(type, STANZA_TYPE_ERROR) == 0) {
@@ -1063,7 +1063,7 @@ _version_result_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
         return 0;
     }
 
-    char *ns = xmpp_stanza_get_ns(query);
+    const char *ns = xmpp_stanza_get_ns(query);
     if (g_strcmp0(ns, STANZA_NS_VERSION) != 0) {
         log_error("Software version result received without namespace.");
         return 0;
@@ -1410,7 +1410,7 @@ _room_config_id_handler(xmpp_stanza_t *const stanza, void *const userdata)
         return 0;
     }
 
-    char *form_type = xmpp_stanza_get_attribute(x, STANZA_ATTR_TYPE);
+    const char *form_type = xmpp_stanza_get_attribute(x, STANZA_ATTR_TYPE);
     if (g_strcmp0(form_type, "form") != 0) {
         log_warning("x element not of type 'form' parsing room config response");
         ui_handle_room_configuration_form_error(from, "Form not of type 'form' parsing room config response.");
@@ -1520,11 +1520,11 @@ _room_affiliation_list_result_id_handler(xmpp_stanza_t *const stanza, void *cons
     if (query) {
         xmpp_stanza_t *child = xmpp_stanza_get_children(query);
         while (child) {
-            char *name = xmpp_stanza_get_name(child);
+            const char *name = xmpp_stanza_get_name(child);
             if (g_strcmp0(name, "item") == 0) {
-                char *jid = xmpp_stanza_get_attribute(child, STANZA_ATTR_JID);
+                const char *jid = xmpp_stanza_get_attribute(child, STANZA_ATTR_JID);
                 if (jid) {
-                    jids = g_slist_insert_sorted(jids, jid, (GCompareFunc)g_strcmp0);
+                    jids = g_slist_insert_sorted(jids, (gpointer)jid, (GCompareFunc)g_strcmp0);
                 }
             }
             child = xmpp_stanza_get_next(child);
@@ -1574,11 +1574,11 @@ _room_role_list_result_id_handler(xmpp_stanza_t *const stanza, void *const userd
     if (query) {
         xmpp_stanza_t *child = xmpp_stanza_get_children(query);
         while (child) {
-            char *name = xmpp_stanza_get_name(child);
+            const char *name = xmpp_stanza_get_name(child);
             if (g_strcmp0(name, "item") == 0) {
-                char *nick = xmpp_stanza_get_attribute(child, STANZA_ATTR_NICK);
+                const char *nick = xmpp_stanza_get_attribute(child, STANZA_ATTR_NICK);
                 if (nick) {
-                    nicks = g_slist_insert_sorted(nicks, nick, (GCompareFunc)g_strcmp0);
+                    nicks = g_slist_insert_sorted(nicks, (gpointer)nick, (GCompareFunc)g_strcmp0);
                 }
             }
             child = xmpp_stanza_get_next(child);
@@ -1781,7 +1781,7 @@ _last_activity_response_id_handler(xmpp_stanza_t *const stanza, void *const user
         return 0;
     }
 
-    char *seconds_str = xmpp_stanza_get_attribute(query, "seconds");
+    const char *seconds_str = xmpp_stanza_get_attribute(query, "seconds");
     if (!seconds_str) {
         cons_show_error("Invalid last activity response received.");
         log_info("Received last activity response with no seconds attribute.");

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -85,7 +85,7 @@ _message_handler(xmpp_conn_t *const conn, xmpp_stanza_t *const stanza, void *con
         return 1;
     }
 
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *type = xmpp_stanza_get_type(stanza);
 
     if (g_strcmp0(type, STANZA_TYPE_ERROR) == 0) {
         _handle_error(stanza);
@@ -382,10 +382,10 @@ message_send_gone(const char *const jid)
 static void
 _handle_error(xmpp_stanza_t *const stanza)
 {
-    char *id = xmpp_stanza_get_id(stanza);
-    char *jid = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *id = xmpp_stanza_get_id(stanza);
+    const char *jid = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     xmpp_stanza_t *error_stanza = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_ERROR);
-    char *type = NULL;
+    const char *type = NULL;
     if (error_stanza) {
         type = xmpp_stanza_get_attribute(error_stanza, STANZA_ATTR_TYPE);
     }
@@ -432,7 +432,7 @@ _handel_muc_user(xmpp_stanza_t *const stanza)
 {
     xmpp_ctx_t *ctx = connection_get_ctx();
     xmpp_stanza_t *xns_muc_user = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_MUC_USER);
-    char *room = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *room = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
 
     if (!room) {
         log_warning("Message received with no from attribute, ignoring");
@@ -445,7 +445,7 @@ _handel_muc_user(xmpp_stanza_t *const stanza)
         return;
     }
 
-    char *invitor_jid = xmpp_stanza_get_attribute(invite, STANZA_ATTR_FROM);
+    const char *invitor_jid = xmpp_stanza_get_attribute(invite, STANZA_ATTR_FROM);
     if (!invitor_jid) {
         log_warning("Chat room invite received with no from attribute");
         return;
@@ -484,7 +484,7 @@ _handle_conference(xmpp_stanza_t *const stanza)
 {
     xmpp_stanza_t *xns_conference = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_CONFERENCE);
 
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     if (!from) {
         log_warning("Message received with no from attribute, ignoring");
         return;
@@ -496,14 +496,14 @@ _handle_conference(xmpp_stanza_t *const stanza)
     }
 
     // XEP-0249
-    char *room = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_JID);
+    const char *room = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_JID);
     if (!room) {
         jid_destroy(jidp);
         return;
     }
 
-    char *reason = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_REASON);
-    char *password = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_PASSWORD);
+    const char *reason = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_REASON);
+    const char *password = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_PASSWORD);
 
     sv_ev_room_invite(INVITE_DIRECT, jidp->barejid, room, reason, password);
     jid_destroy(jidp);
@@ -513,7 +513,7 @@ static void
 _handle_captcha(xmpp_stanza_t *const stanza)
 {
     xmpp_ctx_t *ctx = connection_get_ctx();
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
 
     if (!from) {
         log_warning("Message received with no from attribute, ignoring");
@@ -540,7 +540,7 @@ _handle_groupchat(xmpp_stanza_t *const stanza)
 {
     xmpp_ctx_t *ctx = connection_get_ctx();
     char *message = NULL;
-    char *room_jid = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *room_jid = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     Jid *jid = jid_create(room_jid);
 
     // handle room subject
@@ -642,17 +642,17 @@ static void
 _handle_receipt_received(xmpp_stanza_t *const stanza)
 {
     xmpp_stanza_t *receipt = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_RECEIPTS);
-    char *name = xmpp_stanza_get_name(receipt);
+    const char *name = xmpp_stanza_get_name(receipt);
     if (g_strcmp0(name, "received") != 0) {
         return;
     }
 
-    char *id = xmpp_stanza_get_attribute(receipt, STANZA_ATTR_ID);
+    const char *id = xmpp_stanza_get_attribute(receipt, STANZA_ATTR_ID);
     if (!id) {
         return;
     }
 
-    char *fulljid = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *fulljid = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     if (!fulljid) {
         return;
     }
@@ -669,7 +669,7 @@ _receipt_request_handler(xmpp_stanza_t *const stanza)
         return;
     }
 
-    char *id = xmpp_stanza_get_id(stanza);
+    const char *id = xmpp_stanza_get_id(stanza);
     if (!id) {
         return;
     }
@@ -679,12 +679,12 @@ _receipt_request_handler(xmpp_stanza_t *const stanza)
         return;
     }
 
-    char *receipts_name = xmpp_stanza_get_name(receipts);
+    const char *receipts_name = xmpp_stanza_get_name(receipts);
     if (g_strcmp0(receipts_name, "request") != 0) {
         return;
     }
 
-    gchar *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const gchar *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     Jid *jid = jid_create(from);
     _message_send_receipt(jid->fulljid, id);
     jid_destroy(jid);
@@ -723,15 +723,15 @@ _handle_carbons(xmpp_stanza_t *const stanza)
         return FALSE;
     }
 
-    char *name = xmpp_stanza_get_name(carbons);
+    const char *name = xmpp_stanza_get_name(carbons);
     if ((g_strcmp0(name, "received") == 0) || (g_strcmp0(name, "sent")) == 0) {
         xmpp_stanza_t *forwarded = xmpp_stanza_get_child_by_ns(carbons, STANZA_NS_FORWARD);
         xmpp_stanza_t *message = xmpp_stanza_get_child_by_name(forwarded, STANZA_NAME_MESSAGE);
 
         xmpp_ctx_t *ctx = connection_get_ctx();
 
-        gchar *to = xmpp_stanza_get_attribute(message, STANZA_ATTR_TO);
-        gchar *from = xmpp_stanza_get_attribute(message, STANZA_ATTR_FROM);
+        const gchar *to = xmpp_stanza_get_attribute(message, STANZA_ATTR_TO);
+        const gchar *from = xmpp_stanza_get_attribute(message, STANZA_ATTR_FROM);
 
         // happens when receive a carbon of a self sent message
         if (!to) to = from;
@@ -779,7 +779,7 @@ static void
 _handle_chat(xmpp_stanza_t *const stanza)
 {
     // ignore if type not chat or absent
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *type = xmpp_stanza_get_type(stanza);
     if (!(g_strcmp0(type, "chat") == 0 || type == NULL)) {
         return;
     }
@@ -806,7 +806,7 @@ _handle_chat(xmpp_stanza_t *const stanza)
         return;
     }
 
-    gchar *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const gchar *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     Jid *jid = jid_create(from);
 
     // private message from chat room use full jid (room/nick)

--- a/src/xmpp/presence.c
+++ b/src/xmpp/presence.c
@@ -97,7 +97,7 @@ _presence_handler(xmpp_conn_t *const conn, xmpp_stanza_t *const stanza, void *co
         return 1;
     }
 
-    char *type = xmpp_stanza_get_type(stanza);
+    const char *type = xmpp_stanza_get_type(stanza);
 
     if (g_strcmp0(type, STANZA_TYPE_ERROR) == 0) {
         _presence_error_handler(stanza);
@@ -321,7 +321,7 @@ _send_room_presence(xmpp_stanza_t *presence)
 }
 
 void
-presence_join_room(char *room, char *nick, char * passwd)
+presence_join_room(const char *const room, const char *const nick, const char *const passwd)
 {
     Jid *jid = jid_create_from_bare_and_resource(room, nick);
 
@@ -394,15 +394,15 @@ presence_leave_chat_room(const char *const room_jid)
 static void
 _presence_error_handler(xmpp_stanza_t *const stanza)
 {
-    char *id = xmpp_stanza_get_id(stanza);
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *id = xmpp_stanza_get_id(stanza);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     xmpp_stanza_t *error_stanza = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_ERROR);
     xmpp_stanza_t *x = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_X);
-    char *xmlns = NULL;
+    const char *xmlns = NULL;
     if (x) {
         xmlns = xmpp_stanza_get_ns(x);
     }
-    char *type = NULL;
+    const char *type = NULL;
     if (error_stanza) {
         type = xmpp_stanza_get_attribute(error_stanza, STANZA_ATTR_TYPE);
     }
@@ -411,7 +411,7 @@ _presence_error_handler(xmpp_stanza_t *const stanza)
     if (g_strcmp0(xmlns, STANZA_NS_MUC) == 0) {
         Jid *fulljid = jid_create(from);
 
-        char *error_cond = NULL;
+        const char *error_cond = NULL;
         xmpp_stanza_t *reason_st = xmpp_stanza_get_child_by_ns(error_stanza, STANZA_NS_STANZAS);
         if (reason_st) {
             error_cond = xmpp_stanza_get_name(reason_st);
@@ -465,7 +465,7 @@ _presence_error_handler(xmpp_stanza_t *const stanza)
 static void
 _unsubscribed_handler(xmpp_stanza_t *const stanza)
 {
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     Jid *from_jid = jid_create(from);
     log_debug("Unsubscribed presence handler fired for %s", from);
 
@@ -478,7 +478,7 @@ _unsubscribed_handler(xmpp_stanza_t *const stanza)
 static void
 _subscribed_handler(xmpp_stanza_t *const stanza)
 {
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     Jid *from_jid = jid_create(from);
     log_debug("Subscribed presence handler fired for %s", from);
 
@@ -491,7 +491,7 @@ _subscribed_handler(xmpp_stanza_t *const stanza)
 static void
 _subscribe_handler(xmpp_stanza_t *const stanza)
 {
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     log_debug("Subscribe presence handler fired for %s", from);
 
     Jid *from_jid = jid_create(from);
@@ -512,7 +512,7 @@ _unavailable_handler(xmpp_stanza_t *const stanza)
 
     xmpp_conn_t *conn = connection_get_conn();
     const char *jid = xmpp_conn_get_jid(conn);
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     log_debug("Unavailable presence handler fired for %s", from);
 
     Jid *my_jid = jid_create(jid);
@@ -545,7 +545,7 @@ _unavailable_handler(xmpp_stanza_t *const stanza)
 }
 
 static void
-_handle_caps(char *jid, XMPPCaps *caps)
+_handle_caps(const char *const jid, XMPPCaps *caps)
 {
     // hash supported, xep-0115, cache against ver
     if (g_strcmp0(caps->hash, "sha-1") == 0) {
@@ -607,7 +607,7 @@ _available_handler(xmpp_stanza_t *const stanza)
     XMPPPresence *xmpp_presence = stanza_parse_presence(stanza, &err);
 
     if (!xmpp_presence) {
-        char *from = NULL;
+        const char *from = NULL;
         switch(err) {
             case STANZA_PARSE_ERROR_NO_FROM:
                 log_warning("Available presence handler fired with no from attribute.");
@@ -682,8 +682,8 @@ _muc_user_handler(xmpp_stanza_t *const stanza)
 {
     inp_nonblocking(TRUE);
 
-    char *type = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_TYPE);
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *type = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_TYPE);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
 
     // handler still fires if error
     if (g_strcmp0(type, STANZA_TYPE_ERROR) == 0) {
@@ -703,9 +703,9 @@ _muc_user_handler(xmpp_stanza_t *const stanza)
     char *show_str = stanza_get_show(stanza, "online");
     char *status_str = stanza_get_status(stanza, NULL);
 
-    char *jid = NULL;
-    char *role = NULL;
-    char *affiliation = NULL;
+    const char *jid = NULL;
+    const char *role = NULL;
+    const char *affiliation = NULL;
 
     xmpp_stanza_t *x = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_MUC_USER);
     if (x) {
@@ -725,7 +725,7 @@ _muc_user_handler(xmpp_stanza_t *const stanza)
         if (g_strcmp0(type, STANZA_TYPE_UNAVAILABLE) == 0) {
 
             // handle nickname change
-            char *new_nick = stanza_get_new_nick(stanza);
+            const char *new_nick = stanza_get_new_nick(stanza);
             if (new_nick) {
                 muc_nick_change_start(room, new_nick);
             } else {
@@ -733,7 +733,7 @@ _muc_user_handler(xmpp_stanza_t *const stanza)
 
                 // room destroyed
                 if (stanza_room_destroyed(stanza)) {
-                    char *new_jid = stanza_get_muc_destroy_alternative_room(stanza);
+                    const char *new_jid = stanza_get_muc_destroy_alternative_room(stanza);
                     char *password = stanza_get_muc_destroy_alternative_password(stanza);
                     char *reason = stanza_get_muc_destroy_reason(stanza);
                     sv_ev_room_destroyed(room, new_jid, password, reason);
@@ -742,14 +742,14 @@ _muc_user_handler(xmpp_stanza_t *const stanza)
 
                 // kicked from room
                 } else if (g_slist_find_custom(status_codes, "307", (GCompareFunc)g_strcmp0)) {
-                    char *actor = stanza_get_actor(stanza);
+                    const char *actor = stanza_get_actor(stanza);
                     char *reason = stanza_get_reason(stanza);
                     sv_ev_room_kicked(room, actor, reason);
                     free(reason);
 
                 // banned from room
                 } else if (g_slist_find_custom(status_codes, "301", (GCompareFunc)g_strcmp0)) {
-                    char *actor = stanza_get_actor(stanza);
+                    const char *actor = stanza_get_actor(stanza);
                     char *reason = stanza_get_reason(stanza);
                     sv_ev_room_banned(room, actor, reason);
                     free(reason);
@@ -765,9 +765,10 @@ _muc_user_handler(xmpp_stanza_t *const stanza)
         // self online
         } else {
             gboolean config_required = stanza_muc_requires_config(stanza);
-            char *actor = stanza_get_actor(stanza);
+            const char *actor = stanza_get_actor(stanza);
             char *reason = stanza_get_reason(stanza);
             sv_ev_muc_self_online(room, nick, config_required, role, affiliation, actor, reason, jid, show_str, status_str);
+            free(reason);
         }
 
     // handle presence from room members
@@ -777,7 +778,7 @@ _muc_user_handler(xmpp_stanza_t *const stanza)
         if (g_strcmp0(type, STANZA_TYPE_UNAVAILABLE) == 0) {
 
             // handle nickname change
-            char *new_nick = stanza_get_new_nick(stanza);
+            const char *new_nick = stanza_get_new_nick(stanza);
             if (new_nick) {
                 muc_occupant_nick_change_start(room, new_nick, nick);
 
@@ -787,14 +788,14 @@ _muc_user_handler(xmpp_stanza_t *const stanza)
 
                 // kicked from room
                 if (g_slist_find_custom(status_codes, "307", (GCompareFunc)g_strcmp0)) {
-                    char *actor = stanza_get_actor(stanza);
+                    const char *actor = stanza_get_actor(stanza);
                     char *reason = stanza_get_reason(stanza);
                     sv_ev_room_occupent_kicked(room, nick, actor, reason);
                     free(reason);
 
                 // banned from room
                 } else if (g_slist_find_custom(status_codes, "301", (GCompareFunc)g_strcmp0)) {
-                    char *actor = stanza_get_actor(stanza);
+                    const char *actor = stanza_get_actor(stanza);
                     char *reason = stanza_get_reason(stanza);
                     sv_ev_room_occupent_banned(room, nick, actor, reason);
                     free(reason);
@@ -817,9 +818,10 @@ _muc_user_handler(xmpp_stanza_t *const stanza)
             }
             stanza_free_caps(caps);
 
-            char *actor = stanza_get_actor(stanza);
+            const char *actor = stanza_get_actor(stanza);
             char *reason = stanza_get_reason(stanza);
             sv_ev_muc_occupant_online(room, nick, jid, role, affiliation, actor, reason, show_str, status_str);
+            free(reason);
         }
     }
 

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -1136,9 +1136,9 @@ stanza_get_delay(xmpp_stanza_t *const stanza)
     // first check for XEP-0203 delayed delivery
     xmpp_stanza_t *delay = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_DELAY);
     if (delay) {
-        char *xmlns = xmpp_stanza_get_attribute(delay, STANZA_ATTR_XMLNS);
+        const char *xmlns = xmpp_stanza_get_attribute(delay, STANZA_ATTR_XMLNS);
         if (xmlns && (strcmp(xmlns, "urn:xmpp:delay") == 0)) {
-            char *stamp = xmpp_stanza_get_attribute(delay, STANZA_ATTR_STAMP);
+            const char *stamp = xmpp_stanza_get_attribute(delay, STANZA_ATTR_STAMP);
             if (stamp && (g_time_val_from_iso8601(stamp, &utc_stamp))) {
                 GDateTime *utc_datetime = g_date_time_new_from_timeval_utc(&utc_stamp);
                 GDateTime *local_datetime = g_date_time_to_local(utc_datetime);
@@ -1152,9 +1152,9 @@ stanza_get_delay(xmpp_stanza_t *const stanza)
     // stanp format : CCYYMMDDThh:mm:ss
     xmpp_stanza_t *x = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_X);
     if (x) {
-        char *xmlns = xmpp_stanza_get_attribute(x, STANZA_ATTR_XMLNS);
+        const char *xmlns = xmpp_stanza_get_attribute(x, STANZA_ATTR_XMLNS);
         if (xmlns && (strcmp(xmlns, "jabber:x:delay") == 0)) {
-            char *stamp = xmpp_stanza_get_attribute(x, STANZA_ATTR_STAMP);
+            const char *stamp = xmpp_stanza_get_attribute(x, STANZA_ATTR_STAMP);
             if (stamp && (g_time_val_from_iso8601(stamp, &utc_stamp))) {
                 GDateTime *utc_datetime = g_date_time_new_from_timeval_utc(&utc_stamp);
                 GDateTime *local_datetime = g_date_time_to_local(utc_datetime);
@@ -1251,7 +1251,7 @@ stanza_muc_requires_config(xmpp_stanza_t *const stanza)
         if (item == NULL) {
             return FALSE;
         }
-        char *affiliation = xmpp_stanza_get_attribute(item, "affiliation");
+        const char *affiliation = xmpp_stanza_get_attribute(item, "affiliation");
         if (g_strcmp0(affiliation, "owner") != 0) {
             return FALSE;
         }
@@ -1260,7 +1260,7 @@ stanza_muc_requires_config(xmpp_stanza_t *const stanza)
         xmpp_stanza_t *x_children = xmpp_stanza_get_children(x);
         while (x_children) {
             if (g_strcmp0(xmpp_stanza_get_name(x_children), STANZA_NAME_STATUS) == 0) {
-                char *code = xmpp_stanza_get_attribute(x_children, STANZA_ATTR_CODE);
+                const char *code = xmpp_stanza_get_attribute(x_children, STANZA_ATTR_CODE);
                 if (g_strcmp0(code, "201") == 0) {
                     return TRUE;
                 }
@@ -1288,7 +1288,7 @@ stanza_is_muc_self_presence(xmpp_stanza_t *const stanza,
         xmpp_stanza_t *x_children = xmpp_stanza_get_children(x);
         while (x_children) {
             if (g_strcmp0(xmpp_stanza_get_name(x_children), STANZA_NAME_STATUS) == 0) {
-                char *code = xmpp_stanza_get_attribute(x_children, STANZA_ATTR_CODE);
+                const char *code = xmpp_stanza_get_attribute(x_children, STANZA_ATTR_CODE);
                 if (g_strcmp0(code, "110") == 0) {
                     return TRUE;
                 }
@@ -1299,7 +1299,7 @@ stanza_is_muc_self_presence(xmpp_stanza_t *const stanza,
         // check for item child element with jid property
         xmpp_stanza_t *item = xmpp_stanza_get_child_by_name(x, STANZA_NAME_ITEM);
         if (item) {
-            char *jid = xmpp_stanza_get_attribute(item, STANZA_ATTR_JID);
+            const char *jid = xmpp_stanza_get_attribute(item, STANZA_ATTR_JID);
             if (jid) {
                 if (g_str_has_prefix(self_jid, jid)) {
                     return TRUE;
@@ -1308,7 +1308,7 @@ stanza_is_muc_self_presence(xmpp_stanza_t *const stanza,
         }
 
         // check if 'from' attribute identifies this user
-        char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+        const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
         if (from) {
             Jid *from_jid = jid_create(from);
             if (muc_active(from_jid->barejid)) {
@@ -1348,9 +1348,9 @@ stanza_get_status_codes_by_ns(xmpp_stanza_t *const stanza, char *ns)
     if (ns_child) {
         xmpp_stanza_t *child = xmpp_stanza_get_children(ns_child);
         while (child) {
-            char *name = xmpp_stanza_get_name(child);
+            const char *name = xmpp_stanza_get_name(child);
             if (g_strcmp0(name, STANZA_NAME_STATUS) == 0) {
-                char *code = xmpp_stanza_get_attribute(child, STANZA_ATTR_CODE);
+                const char *code = xmpp_stanza_get_attribute(child, STANZA_ATTR_CODE);
                 if (code) {
                     codes = g_slist_append(codes, strdup(code));
                 }
@@ -1364,7 +1364,7 @@ stanza_get_status_codes_by_ns(xmpp_stanza_t *const stanza, char *ns)
 gboolean
 stanza_room_destroyed(xmpp_stanza_t *stanza)
 {
-    char *stanza_name = xmpp_stanza_get_name(stanza);
+    const char *stanza_name = xmpp_stanza_get_name(stanza);
     if (g_strcmp0(stanza_name, STANZA_NAME_PRESENCE) == 0) {
         xmpp_stanza_t *x = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_MUC_USER);
         if (x) {
@@ -1378,16 +1378,16 @@ stanza_room_destroyed(xmpp_stanza_t *stanza)
     return FALSE;
 }
 
-char*
+const char*
 stanza_get_muc_destroy_alternative_room(xmpp_stanza_t *stanza)
 {
-    char *stanza_name = xmpp_stanza_get_name(stanza);
+    const char *stanza_name = xmpp_stanza_get_name(stanza);
     if (g_strcmp0(stanza_name, STANZA_NAME_PRESENCE) == 0) {
         xmpp_stanza_t *x = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_MUC_USER);
         if (x) {
             xmpp_stanza_t *destroy = xmpp_stanza_get_child_by_name(x, STANZA_NAME_DESTROY);
             if (destroy) {
-                char *jid = xmpp_stanza_get_attribute(destroy, STANZA_ATTR_JID);
+                const char *jid = xmpp_stanza_get_attribute(destroy, STANZA_ATTR_JID);
                 if (jid) {
                     return jid;
                 }
@@ -1401,7 +1401,7 @@ stanza_get_muc_destroy_alternative_room(xmpp_stanza_t *stanza)
 char*
 stanza_get_muc_destroy_alternative_password(xmpp_stanza_t *stanza)
 {
-    char *stanza_name = xmpp_stanza_get_name(stanza);
+    const char *stanza_name = xmpp_stanza_get_name(stanza);
     if (g_strcmp0(stanza_name, STANZA_NAME_PRESENCE) == 0) {
         xmpp_stanza_t *x = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_MUC_USER);
         if (x) {
@@ -1423,7 +1423,7 @@ stanza_get_muc_destroy_alternative_password(xmpp_stanza_t *stanza)
 char*
 stanza_get_muc_destroy_reason(xmpp_stanza_t *stanza)
 {
-    char *stanza_name = xmpp_stanza_get_name(stanza);
+    const char *stanza_name = xmpp_stanza_get_name(stanza);
     if (g_strcmp0(stanza_name, STANZA_NAME_PRESENCE) == 0) {
         xmpp_stanza_t *x = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_MUC_USER);
         if (x) {
@@ -1442,10 +1442,10 @@ stanza_get_muc_destroy_reason(xmpp_stanza_t *stanza)
     return NULL;
 }
 
-char*
+const char*
 stanza_get_actor(xmpp_stanza_t *stanza)
 {
-    char *stanza_name = xmpp_stanza_get_name(stanza);
+    const char *stanza_name = xmpp_stanza_get_name(stanza);
     if (g_strcmp0(stanza_name, STANZA_NAME_PRESENCE) == 0) {
         xmpp_stanza_t *x = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_MUC_USER);
         if (x) {
@@ -1453,11 +1453,11 @@ stanza_get_actor(xmpp_stanza_t *stanza)
             if (item) {
                 xmpp_stanza_t *actor = xmpp_stanza_get_child_by_name(item, STANZA_NAME_ACTOR);
                 if (actor) {
-                    char *nick = xmpp_stanza_get_attribute(actor, STANZA_ATTR_NICK);
+                    const char *nick = xmpp_stanza_get_attribute(actor, STANZA_ATTR_NICK);
                     if (nick) {
                         return nick;
                     }
-                    char *jid = xmpp_stanza_get_attribute(actor, STANZA_ATTR_JID);
+                    const char *jid = xmpp_stanza_get_attribute(actor, STANZA_ATTR_JID);
                     if (jid) {
                         return jid;
                     }
@@ -1471,7 +1471,7 @@ stanza_get_actor(xmpp_stanza_t *stanza)
 char*
 stanza_get_reason(xmpp_stanza_t *stanza)
 {
-    char *stanza_name = xmpp_stanza_get_name(stanza);
+    const char *stanza_name = xmpp_stanza_get_name(stanza);
     if (g_strcmp0(stanza_name, STANZA_NAME_PRESENCE) == 0) {
         xmpp_stanza_t *x = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_MUC_USER);
         if (x) {
@@ -1479,6 +1479,9 @@ stanza_get_reason(xmpp_stanza_t *stanza)
             if (item) {
                 xmpp_stanza_t *reason_st = xmpp_stanza_get_child_by_name(item, STANZA_NAME_REASON);
                 if (reason_st) {
+                    /* TODO don't return text generated by xmpp_stanza_get_text(),
+                     * because it should be freed by xmpp_free(). Instead, return
+                     * strdup(reason) and free the `reason'. Check similar places. */
                     char *reason = xmpp_stanza_get_text(reason_st);
                     if (reason) {
                         return reason;
@@ -1506,7 +1509,7 @@ stanza_is_room_nick_change(xmpp_stanza_t *const stanza)
         xmpp_stanza_t *x_children = xmpp_stanza_get_children(x);
         while (x_children) {
             if (g_strcmp0(xmpp_stanza_get_name(x_children), STANZA_NAME_STATUS) == 0) {
-                char *code = xmpp_stanza_get_attribute(x_children, STANZA_ATTR_CODE);
+                const char *code = xmpp_stanza_get_attribute(x_children, STANZA_ATTR_CODE);
                 if (g_strcmp0(code, "303") == 0) {
                     return TRUE;
                 }
@@ -1518,7 +1521,7 @@ stanza_is_room_nick_change(xmpp_stanza_t *const stanza)
     return FALSE;
 }
 
-char*
+const char*
 stanza_get_new_nick(xmpp_stanza_t *const stanza)
 {
     if (!stanza_is_room_nick_change(stanza)) {
@@ -1530,7 +1533,7 @@ stanza_get_new_nick(xmpp_stanza_t *const stanza)
 
     while (x_children) {
         if (strcmp(xmpp_stanza_get_name(x_children), STANZA_NAME_ITEM) == 0) {
-            char *nick = xmpp_stanza_get_attribute(x_children, STANZA_ATTR_NICK);
+            const char *nick = xmpp_stanza_get_attribute(x_children, STANZA_ATTR_NICK);
             if (nick) {
                 return nick;
             }
@@ -1550,7 +1553,7 @@ stanza_get_idle_time(xmpp_stanza_t *const stanza)
         return 0;
     }
 
-    char *ns = xmpp_stanza_get_ns(query);
+    const char *ns = xmpp_stanza_get_ns(query);
     if (ns == NULL) {
         return 0;
     }
@@ -1559,7 +1562,7 @@ stanza_get_idle_time(xmpp_stanza_t *const stanza)
         return 0;
     }
 
-    char *seconds_str = xmpp_stanza_get_attribute(query, STANZA_ATTR_SECONDS);
+    const char *seconds_str = xmpp_stanza_get_attribute(query, STANZA_ATTR_SECONDS);
     if (seconds_str == NULL) {
         return 0;
     }
@@ -1581,14 +1584,14 @@ stanza_parse_caps(xmpp_stanza_t *const stanza)
         return NULL;
     }
 
-    char *ns = xmpp_stanza_get_ns(caps_st);
+    const char *ns = xmpp_stanza_get_ns(caps_st);
     if (g_strcmp0(ns, STANZA_NS_CAPS) != 0) {
         return NULL;
     }
 
-    char *hash = xmpp_stanza_get_attribute(caps_st, STANZA_ATTR_HASH);
-    char *node = xmpp_stanza_get_attribute(caps_st, STANZA_ATTR_NODE);
-    char *ver = xmpp_stanza_get_attribute(caps_st, STANZA_ATTR_VER);
+    const char *hash = xmpp_stanza_get_attribute(caps_st, STANZA_ATTR_HASH);
+    const char *node = xmpp_stanza_get_attribute(caps_st, STANZA_ATTR_NODE);
+    const char *ver = xmpp_stanza_get_attribute(caps_st, STANZA_ATTR_VER);
 
     XMPPCaps *caps = (XMPPCaps *)malloc(sizeof(XMPPCaps));
     caps->hash = hash ? strdup(hash) : NULL;
@@ -1611,8 +1614,8 @@ stanza_get_caps_str(xmpp_stanza_t *const stanza)
         return NULL;
     }
 
-    char *node = xmpp_stanza_get_attribute(caps, STANZA_ATTR_NODE);
-    char *ver = xmpp_stanza_get_attribute(caps, STANZA_ATTR_VER);
+    const char *node = xmpp_stanza_get_attribute(caps, STANZA_ATTR_NODE);
+    const char *ver = xmpp_stanza_get_attribute(caps, STANZA_ATTR_VER);
 
     if ((node == NULL) || (ver == NULL)) {
         return NULL;
@@ -1848,7 +1851,7 @@ stanza_free_presence(XMPPPresence *presence)
 XMPPPresence*
 stanza_parse_presence(xmpp_stanza_t *stanza, int *err)
 {
-    char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    const char *from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
     if (!from) {
         *err = STANZA_PARSE_ERROR_NO_FROM;
         return NULL;

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -258,7 +258,7 @@ gboolean stanza_is_muc_self_presence(xmpp_stanza_t *const stanza,
 gboolean stanza_is_room_nick_change(xmpp_stanza_t *const stanza);
 gboolean stanza_muc_requires_config(xmpp_stanza_t *const stanza);
 
-char* stanza_get_new_nick(xmpp_stanza_t *const stanza);
+const char* stanza_get_new_nick(xmpp_stanza_t *const stanza);
 xmpp_stanza_t* stanza_create_instant_room_request_iq(xmpp_ctx_t *ctx, const char *const room_jid);
 xmpp_stanza_t* stanza_create_instant_room_destroy_iq(xmpp_ctx_t *ctx, const char *const room_jid);
 xmpp_stanza_t* stanza_create_room_config_request_iq(xmpp_ctx_t *ctx, const char *const room_jid);
@@ -303,10 +303,10 @@ char* stanza_get_error_message(xmpp_stanza_t *const stanza);
 
 GSList* stanza_get_status_codes_by_ns(xmpp_stanza_t *const stanza, char *ns);
 gboolean stanza_room_destroyed(xmpp_stanza_t *stanza);
-char* stanza_get_muc_destroy_alternative_room(xmpp_stanza_t *stanza);
+const char* stanza_get_muc_destroy_alternative_room(xmpp_stanza_t *stanza);
 char* stanza_get_muc_destroy_alternative_password(xmpp_stanza_t *stanza);
 char* stanza_get_muc_destroy_reason(xmpp_stanza_t *stanza);
-char* stanza_get_actor(xmpp_stanza_t *stanza);
+const char* stanza_get_actor(xmpp_stanza_t *stanza);
 char* stanza_get_reason(xmpp_stanza_t *stanza);
 
 Resource* stanza_resource_from_presence(XMPPPresence *presence);

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -148,7 +148,7 @@ GSList* presence_get_subscription_requests(void);
 gint presence_sub_request_count(void);
 void presence_reset_sub_request_search(void);
 char* presence_sub_request_find(const char *const search_str);
-void presence_join_room(char *room, char *nick, char * passwd);
+void presence_join_room(const char *const room, const char *const nick, const char *const passwd);
 void presence_change_room_nick(const char *const room, const char *const nick);
 void presence_leave_chat_room(const char *const room_jid);
 void presence_send(resource_presence_t status, const char *const msg, int idle, char *signed_status);


### PR DESCRIPTION
In most get-like funcitons libstrophe returns pointer to a string
that resides in an internal structure (e.g. xmpp_stanza_t). Hence,
Profanity must not change such strings. Define respective variables
as 'const char*' to reduce a chance of error and conform future
libstrophe's interface.

This patch mostly replaces 'char *' with 'const char*', but also
fixes two memory leaks after stanza_get_reason(). Add comment within
stanza_get_reason() to fix conflict with different allocator types.