### PR TITLE
Correct minor spelling errors

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -6486,7 +6486,7 @@ cmd_pgp(ProfWin *window, const char *const command, gchar **args)
         }
 
         chatwin->pgp_send = TRUE;
-        ui_current_print_formatted_line('!', 0, "PGP encyption enabled.");
+        ui_current_print_formatted_line('!', 0, "PGP encryption enabled.");
         return TRUE;
     }
 
@@ -6509,7 +6509,7 @@ cmd_pgp(ProfWin *window, const char *const command, gchar **args)
         }
 
         chatwin->pgp_send = FALSE;
-        ui_current_print_formatted_line('!', 0, "PGP encyption disabled.");
+        ui_current_print_formatted_line('!', 0, "PGP encryption disabled.");
         return TRUE;
     }
 

--- a/src/otr/otrlibv4.c
+++ b/src/otr/otrlibv4.c
@@ -120,7 +120,7 @@ cb_handle_msg_event(void *opdata, OtrlMessageEvent msg_event,
             ui_handle_otr_error(context->username, "OTR: Policy requires encryption, but attempting to send an unencrypted message.");
             break;
         case OTRL_MSGEVENT_ENCRYPTION_ERROR:
-             ui_handle_otr_error(context->username, "OTR: Error occured while encrypting a message, message not sent.");
+             ui_handle_otr_error(context->username, "OTR: Error occurred while encrypting a message, message not sent.");
             break;
         case OTRL_MSGEVENT_CONNECTION_ENDED:
             ui_handle_otr_error(context->username, "OTR: Message not sent because contact has ended the private conversation.");

--- a/src/ui/notifier.c
+++ b/src/ui/notifier.c
@@ -140,7 +140,7 @@ notify_subscription(const char *const from)
 {
     GString *message = g_string_new("Subscription request: \n");
     g_string_append(message, from);
-    notify(message->str, 10000, "Incomming message");
+    notify(message->str, 10000, "Incoming message");
     g_string_free(message, TRUE);
 }
 


### PR DESCRIPTION
While packaging the new 0.5.0 upstream release I came across a few spelling mistakes
Hope this helps :-)