### PR TITLE
Redraw the screen after entry of the PGP secret key passphrase

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -118,6 +118,16 @@ sv_ev_roster_received(void)
             cons_show_error("Invalid PGP key ID specified: %s, %s", account->pgp_keyid, err_str);
         }
         free(err_str);
+
+        // Redraw the screen after entry of the PGP secret key
+        ProfWin *win = wins_get_current();
+        char *theme = prefs_get_string(PREF_THEME);
+        win_clear(win);
+        theme_init(theme);
+        prefs_free_string(theme);
+        ui_init();
+        ui_resize();
+        ui_show_roster();
     }
     account_free(account);
 #endif


### PR DESCRIPTION
This might not be the most elegant way to do it, but this causes the screen to be redrawn after entering the PGP secret key passphrase on startup if pgp.keyid is set within the accounts file. It prevents the screen from appearing to be completely broken.

The problem seems to be that entering the secret key passphrase initiates a callback function which displays the input box, and when that callback is finished and the input box goes away then nothing happens to redraw the screen as it previously was.