### PR TITLE
Ignore accents when doing tab-completion for names

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,11 @@ PKG_CHECK_MODULES([libmesode], [libmesode],
         [LIBS="$libstrophe_LIBS $LIBS" CFLAGS="$CFLAGS $libstrophe_CFLAGS" AC_DEFINE([HAVE_LIBSTROPHE], [1], [libstrophe])],
         [AC_MSG_ERROR([Neither libmesode or libstrophe found, either is required for profanity])])])
 
+### Check for icu
+PKG_CHECK_MODULES([icu_i18n], [icu-i18n],
+    [LIBS="$icu_i18n_LIBS $LIBS" CFLAGS="$CFLAGS $icu_i18n_CFLAGS" AC_DEFINE([HAVE_ICU_I18N], [1], [icu_i18n])],
+    [AC_MSG_WARN([icu_i18n is not available])])
+
 ### Check for ncurses library
 PKG_CHECK_MODULES([ncursesw], [ncursesw],
     [NCURSES_CFLAGS="$ncursesw_CFLAGS"; NCURSES_LIBS="$ncursesw_LIBS"; NCURSES="ncursesw"],

--- a/src/tools/autocomplete.c
+++ b/src/tools/autocomplete.c
@@ -126,7 +126,7 @@ autocomplete_length(Autocomplete ac)
     }
 }
 
-#ifdef HAVE_ICU_I20N
+#ifdef HAVE_ICU_I18N
 static int ucompare(gconstpointer a, gconstpointer b, gpointer data)
 {
   UChar ua[strlen (a) + 1];

--- a/src/tools/autocomplete.h
+++ b/src/tools/autocomplete.h
@@ -54,6 +54,11 @@ void autocomplete_add_all(Autocomplete ac, char **items);
 void autocomplete_remove(Autocomplete ac, const char *const item);
 void autocomplete_remove_all(Autocomplete ac, char **items);
 
+// find the next item prefixed with search string, ignoring accents
+gchar* autocomplete_complete_ignore_accents(Autocomplete ac,
+					    const gchar *search_str,
+					    gboolean quote);
+
 // find the next item prefixed with search string
 gchar* autocomplete_complete(Autocomplete ac, const gchar *search_str, gboolean quote);
 

--- a/src/xmpp/roster_list.c
+++ b/src/xmpp/roster_list.c
@@ -476,7 +476,7 @@ roster_contact_autocomplete(const char *const search_str)
 {
     assert(roster != NULL);
 
-    return autocomplete_complete(roster->name_ac, search_str, TRUE);
+    return autocomplete_complete_ignore_accents(roster->name_ac, search_str, TRUE);
 }
 
 char*


### PR DESCRIPTION
Use libicu, if available, to transliterate candidate strings
to remove accents before doing tab-completion.

This allows e.g.

/msg S<tab>

to match e.g. Slovak "Štefan" without having to deal with local
keyboard layout...

Signed-off-by: Klement Sekera <klement.sekera@gmail.com>