### PR TITLE
Legacy SSL support

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -568,6 +568,7 @@ cmd_ac_init(void)
     tls_property_ac = autocomplete_new();
     autocomplete_add(tls_property_ac, "force");
     autocomplete_add(tls_property_ac, "allow");
+    autocomplete_add(tls_property_ac, "legacy");
     autocomplete_add(tls_property_ac, "disable");
 
     join_property_ac = autocomplete_new();

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -158,7 +158,7 @@ static struct cmd_t command_defs[] =
             CMD_TAG_CONNECTION)
         CMD_SYN(
             "/connect [<account>]",
-            "/connect <account> [server <server>] [port <port>] [tls force|allow|disable]")
+            "/connect <account> [server <server>] [port <port>] [tls force|allow|legacy|disable]")
         CMD_DESC(
             "Login to a chat service. "
             "If no account is specified, the default is used if one is configured. "
@@ -169,6 +169,7 @@ static struct cmd_t command_defs[] =
             { "port <port>",       "The port to use if different to the default (5222, or 5223 for SSL)." },
             { "tls force",         "Force TLS connection, and fail if one cannot be established, this is default behaviour." },
             { "tls allow",         "Use TLS for the connection if it is available." },
+            { "tls legacy",        "Use legacy TLS for the connection. It means server doesn't support STARTTLS and TLS is forced just after TCP connection is established." },
             { "tls disable",       "Disable TLS for the connection." })
         CMD_EXAMPLES(
             "/connect",
@@ -1984,7 +1985,7 @@ static struct cmd_t command_defs[] =
             "/account set <account> otr <policy>",
             "/account set <account> pgpkeyid <pgpkeyid>",
             "/account set <account> startscript <script>",
-            "/account set <account> tls force|allow|disable",
+            "/account set <account> tls force|allow|legacy|disable",
             "/account set <account> theme <theme>",
             "/account clear <account> password",
             "/account clear <account> eval_password",
@@ -2024,6 +2025,7 @@ static struct cmd_t command_defs[] =
             { "set <account> startscript <script>",     "Set the script to execute after connecting." },
             { "set <account> tls force",                "Force TLS connection, and fail if one cannot be established, this is default behaviour." },
             { "set <account> tls allow",                "Use TLS for the connection if it is available." },
+            { "set <account> tls legacy",               "Use legacy TLS for the connection. It means server doesn't support STARTTLS and TLS is forced just after TCP connection is established." },
             { "set <account> tls disable",              "Disable TLS for the connection." },
             { "set <account> <theme>",                  "Set the UI theme for the account." },
             { "clear <account> server",                 "Remove the server setting for this account." },

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -350,7 +350,8 @@ cmd_connect(ProfWin *window, const char *const command, gchar **args)
     if (tls_policy &&
             (g_strcmp0(tls_policy, "force") != 0) &&
             (g_strcmp0(tls_policy, "allow") != 0) &&
-            (g_strcmp0(tls_policy, "disable") != 0)) {
+            (g_strcmp0(tls_policy, "disable") != 0) &&
+            (g_strcmp0(tls_policy, "legacy") != 0)) {
         cons_bad_cmd_usage(command);
         cons_show("");
         return TRUE;
@@ -813,8 +814,9 @@ _account_set_tls(char *account_name, char *policy)
 {
     if ((g_strcmp0(policy, "force") != 0)
             && (g_strcmp0(policy, "allow") != 0)
-            && (g_strcmp0(policy, "disable") != 0)) {
-        cons_show("TLS policy must be one of: force, allow or disable.");
+            && (g_strcmp0(policy, "disable") != 0)
+            && (g_strcmp0(policy, "legacy") != 0)) {
+        cons_show("TLS policy must be one of: force, allow, legacy or disable.");
     } else {
         accounts_set_tls_policy(account_name, policy);
         cons_show("Updated TLS policy for account %s: %s", account_name, policy);

--- a/src/config/accounts.c
+++ b/src/config/accounts.c
@@ -291,7 +291,8 @@ accounts_get_account(const char *const name)
         gchar *tls_policy = g_key_file_get_string(accounts, name, "tls.policy", NULL);
         if (tls_policy && ((g_strcmp0(tls_policy, "force") != 0) &&
                 (g_strcmp0(tls_policy, "allow") != 0) &&
-                (g_strcmp0(tls_policy, "disable") != 0))) {
+                (g_strcmp0(tls_policy, "disable") != 0) &&
+                (g_strcmp0(tls_policy, "legacy") != 0))) {
             g_free(tls_policy);
             tls_policy = NULL;
         }

--- a/src/xmpp/connection.c
+++ b/src/xmpp/connection.c
@@ -152,6 +152,8 @@ connection_connect(const char *const jid, const char *const passwd, const char *
         xmpp_conn_set_flags(conn.xmpp_conn, XMPP_CONN_FLAG_MANDATORY_TLS);
     } else if (g_strcmp0(tls_policy, "disable") == 0) {
         xmpp_conn_set_flags(conn.xmpp_conn, XMPP_CONN_FLAG_DISABLE_TLS);
+    } else if (g_strcmp0(tls_policy, "legacy") == 0) {
+        xmpp_conn_set_flags(conn.xmpp_conn, XMPP_CONN_FLAG_LEGACY_SSL);
     }
 
 #ifdef HAVE_LIBMESODE


### PR DESCRIPTION
Add `legacy` tls policy to /account and /connect commands. When this
policy is specified the connection is connected with
XMPP_CONN_LEGACY_SSL flag. Notice, legacy SSL and STARTTLS are not
compatible and user has to know when exactly the new policy should be
used.

To enable it, run one of the next commands:
```
  /connect <jid> tls legacy [server <host>]
  /account <name> set tls legacy
```

Notice, there is no SRV record for legacy SSL. Therefore, you may need
`server` property to connect successfully. Refer to configuration
provided by your server.

This patch closes #536.