### PR TITLE
let plugins_unload_all fail if one plugin unload operation fails

### DIFF
--- a/src/plugins/plugins.c
+++ b/src/plugins/plugins.c
@@ -247,7 +247,7 @@ plugins_load(const char *const name)
 gboolean
 plugins_unload_all(void)
 {
-    gboolean result = FALSE;
+    gboolean result = TRUE;
     GList *plugin_names = g_hash_table_get_keys(plugins);
     GList *plugin_names_dup = NULL;
     GList *curr = plugin_names;
@@ -259,8 +259,8 @@ plugins_unload_all(void)
 
     curr = plugin_names_dup;
     while (curr) {
-        if (plugins_unload(curr->data)) {
-            result = TRUE;
+        if (!plugins_unload(curr->data)) {
+            result = FALSE;
         }
         curr = g_list_next(curr);
     }


### PR DESCRIPTION
previously TRUE was returned once one unload operation succeeded