### PR TITLE
Fix gcc8 error about strncpy

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -228,7 +228,7 @@ _rotate_log_file(void)
     size_t len = strlen(log_file);
     char *log_file_new = malloc(len + 3);
 
-    strncpy(log_file_new, log_file, len);
+    memcpy(log_file_new, log_file, len);
     log_file_new[len] = '.';
     log_file_new[len+1] = '1';
     log_file_new[len+2] = 0;


### PR DESCRIPTION
With gcc8 we get the following error when stringop-truncation is on:

```
In function ‘_rotate_log_file’,
    inlined from ‘log_msg.part.2’ at src/log.c:201:17:
src/log.c:231:5: error: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
     strncpy(log_file_new, log_file, len);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/log.c: In function ‘log_msg.part.2’:
src/log.c:228:18: note: length computed here
     size_t len = strlen(log_file);
                  ^~~~~~~~~~~~~~~~
```

Using memcpy instead of strncpy.