### PR TITLE
tests: remove cflag -w and fix warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -228,7 +228,6 @@ endif
 TESTS = tests/unittests/unittests
 check_PROGRAMS = tests/unittests/unittests
 tests_unittests_unittests_SOURCES = $(unittest_sources)
-tests_unittests_unittests_CFLAGS = -w
 tests_unittests_unittests_LDADD = -lcmocka
 
 # Functional test were commented out because of:

--- a/tests/unittests/test_autocomplete.c
+++ b/tests/unittests/test_autocomplete.c
@@ -31,12 +31,12 @@ void find_after_create(void **state)
 void get_after_create_returns_null(void **state)
 {
     Autocomplete ac = autocomplete_new();
-    GSList *result = autocomplete_create_list(ac);
+    GList *result = autocomplete_create_list(ac);
 
     assert_null(result);
 
     autocomplete_clear(ac);
-    g_slist_free_full(result, g_free);
+    g_list_free_full(result, free);
 }
 
 void add_one_and_complete(void **state)
@@ -80,12 +80,12 @@ void add_two_adds_two(void **state)
     Autocomplete ac = autocomplete_new();
     autocomplete_add(ac, "Hello");
     autocomplete_add(ac, "Help");
-    GSList *result = autocomplete_create_list(ac);
+    GList *result = autocomplete_create_list(ac);
 
-    assert_int_equal(2, g_slist_length(result));
+    assert_int_equal(2, g_list_length(result));
 
     autocomplete_clear(ac);
-    g_slist_free_full(result, g_free);
+    g_list_free_full(result, free);
 }
 
 void add_two_same_adds_one(void **state)
@@ -93,12 +93,12 @@ void add_two_same_adds_one(void **state)
     Autocomplete ac = autocomplete_new();
     autocomplete_add(ac, "Hello");
     autocomplete_add(ac, "Hello");
-    GSList *result = autocomplete_create_list(ac);
+    GList *result = autocomplete_create_list(ac);
 
-    assert_int_equal(1, g_slist_length(result));
+    assert_int_equal(1, g_list_length(result));
 
     autocomplete_clear(ac);
-    g_slist_free_full(result, g_free);
+    g_list_free_full(result, free);
 }
 
 void add_two_same_updates(void **state)
@@ -106,16 +106,16 @@ void add_two_same_updates(void **state)
     Autocomplete ac = autocomplete_new();
     autocomplete_add(ac, "Hello");
     autocomplete_add(ac, "Hello");
-    GSList *result = autocomplete_create_list(ac);
+    GList *result = autocomplete_create_list(ac);
 
-    GSList *first = g_slist_nth(result, 0);
+    GList *first = g_list_nth(result, 0);
 
     char *str = first->data;
 
     assert_string_equal("Hello", str);
 
     autocomplete_clear(ac);
-    g_slist_free_full(result, g_free);
+    g_list_free_full(result, free);
 }
 
 void complete_accented_with_accented(void **state)

--- a/tests/unittests/test_cmd_bookmark.c
+++ b/tests/unittests/test_cmd_bookmark.c
@@ -62,12 +62,14 @@ void cmd_bookmark_shows_usage_when_no_args(void **state)
     assert_true(result);
 }
 
+/*
 static void _free_bookmark(Bookmark *bookmark)
 {
     free(bookmark->barejid);
     free(bookmark->nick);
     free(bookmark);
 }
+*/
 
 static gboolean
 _cmp_bookmark(Bookmark *bm1, Bookmark *bm2)
@@ -187,7 +189,7 @@ void cmd_bookmark_uses_roomjid_in_room(void **state)
 
     expect_win_println("Bookmark added for room@conf.server.");
 
-    gboolean result = cmd_bookmark(&muc_win, CMD_BOOKMARK, args);
+    gboolean result = cmd_bookmark(&muc_win.window, CMD_BOOKMARK, args);
     assert_true(result);
 
     muc_close();
@@ -213,7 +215,7 @@ void cmd_bookmark_add_uses_roomjid_in_room(void **state)
 
     expect_win_println("Bookmark added for room@conf.server.");
 
-    gboolean result = cmd_bookmark(&muc_win, CMD_BOOKMARK, args);
+    gboolean result = cmd_bookmark(&muc_win.window, CMD_BOOKMARK, args);
     assert_true(result);
 
     muc_close();
@@ -240,7 +242,7 @@ void cmd_bookmark_add_uses_supplied_jid_in_room(void **state)
 
     expect_cons_show("Bookmark added for room1@conf.server.");
 
-    gboolean result = cmd_bookmark(&muc_win, CMD_BOOKMARK, args);
+    gboolean result = cmd_bookmark(&muc_win.window, CMD_BOOKMARK, args);
     assert_true(result);
 
     muc_close();
@@ -364,7 +366,7 @@ void cmd_bookmark_remove_uses_roomjid_in_room(void **state)
 
     expect_win_println("Bookmark removed for room@conf.server.");
 
-    gboolean result = cmd_bookmark(&muc_win, CMD_BOOKMARK, args);
+    gboolean result = cmd_bookmark(&muc_win.window, CMD_BOOKMARK, args);
     assert_true(result);
 
     muc_close();
@@ -388,7 +390,7 @@ void cmd_bookmark_remove_uses_supplied_jid_in_room(void **state)
 
     expect_cons_show("Bookmark removed for room1@conf.server.");
 
-    gboolean result = cmd_bookmark(&muc_win, CMD_BOOKMARK, args);
+    gboolean result = cmd_bookmark(&muc_win.window, CMD_BOOKMARK, args);
     assert_true(result);
 
     muc_close();

--- a/tests/unittests/test_common.c
+++ b/tests/unittests/test_common.c
@@ -1,3 +1,4 @@
+#include "xmpp/resource.h"
 #include "common.h"
 #include <stdarg.h>
 #include <stddef.h>
@@ -316,8 +317,8 @@ _lists_equal(GSList *a, GSList *b)
             return FALSE;
         }
 
-        curra = g_list_next(curra);
-        currb = g_list_next(currb);
+        curra = g_slist_next(curra);
+        currb = g_slist_next(currb);
     }
 
     return TRUE;

--- a/tests/unittests/test_plugins_disco.c
+++ b/tests/unittests/test_plugins_disco.c
@@ -64,11 +64,11 @@ returns_all_added_features(void **state)
     GList *features = disco_get_features();
 
     assert_int_equal(g_list_length(features), 5);
-    assert_true(g_list_find_custom(features, "first:feature", g_strcmp0));
-    assert_true(g_list_find_custom(features, "second:feature", g_strcmp0));
-    assert_true(g_list_find_custom(features, "third:feature", g_strcmp0));
-    assert_true(g_list_find_custom(features, "fourth:feature", g_strcmp0));
-    assert_true(g_list_find_custom(features, "fifth:feature", g_strcmp0));
+    assert_true(g_list_find_custom(features, "first:feature", (GCompareFunc)g_strcmp0));
+    assert_true(g_list_find_custom(features, "second:feature", (GCompareFunc)g_strcmp0));
+    assert_true(g_list_find_custom(features, "third:feature", (GCompareFunc)g_strcmp0));
+    assert_true(g_list_find_custom(features, "fourth:feature", (GCompareFunc)g_strcmp0));
+    assert_true(g_list_find_custom(features, "fifth:feature", (GCompareFunc)g_strcmp0));
 
     g_list_free(features);
     disco_close();

--- a/tests/unittests/test_roster_list.c
+++ b/tests/unittests/test_roster_list.c
@@ -275,10 +275,10 @@ void add_contact_with_no_group(void **state)
     roster_create();
     roster_add("person@server.org", NULL, NULL, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 0);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 0);
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -290,14 +290,14 @@ void add_contact_with_group(void **state)
     groups = g_slist_append(groups, strdup("friends"));
     roster_add("person@server.org", NULL, groups, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 1);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 1);
 
-    GSList *found = g_slist_find_custom(groups_res, "friends", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "friends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "friends");
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -310,17 +310,17 @@ void add_contact_with_two_groups(void **state)
     groups = g_slist_append(groups, strdup("work"));
     roster_add("person@server.org", NULL, groups, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 2);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 2);
 
-    GSList *found = g_slist_find_custom(groups_res, "friends", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "friends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "friends");
-    found = g_slist_find_custom(groups_res, "work", g_strcmp0);
+    found = g_list_find_custom(groups_res, "work", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "work");
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -334,20 +334,20 @@ void add_contact_with_three_groups(void **state)
     groups = g_slist_append(groups, strdup("stuff"));
     roster_add("person@server.org", NULL, groups, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 3);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 3);
 
-    GSList *found = g_slist_find_custom(groups_res, "friends", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "friends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "friends");
-    found = g_slist_find_custom(groups_res, "work", g_strcmp0);
+    found = g_list_find_custom(groups_res, "work", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "work");
-    found = g_slist_find_custom(groups_res, "stuff", g_strcmp0);
+    found = g_list_find_custom(groups_res, "stuff", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "stuff");
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -369,26 +369,26 @@ void add_contact_with_three_groups_update_adding_two(void **state)
     groups2 = g_slist_append(groups2, strdup("people"));
     roster_update("person@server.org", NULL, groups2, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 5);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 5);
 
-    GSList *found = g_slist_find_custom(groups_res, "friends", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "friends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "friends");
-    found = g_slist_find_custom(groups_res, "work", g_strcmp0);
+    found = g_list_find_custom(groups_res, "work", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "work");
-    found = g_slist_find_custom(groups_res, "stuff", g_strcmp0);
+    found = g_list_find_custom(groups_res, "stuff", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "stuff");
-    found = g_slist_find_custom(groups_res, "things", g_strcmp0);
+    found = g_list_find_custom(groups_res, "things", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "things");
-    found = g_slist_find_custom(groups_res, "people", g_strcmp0);
+    found = g_list_find_custom(groups_res, "people", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "people");
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -407,17 +407,17 @@ void add_contact_with_three_groups_update_removing_one(void **state)
     groups2 = g_slist_append(groups2, strdup("stuff"));
     roster_update("person@server.org", NULL, groups2, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 2);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 2);
 
-    GSList *found = g_slist_find_custom(groups_res, "friends", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "friends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "friends");
-    found = g_slist_find_custom(groups_res, "stuff", g_strcmp0);
+    found = g_list_find_custom(groups_res, "stuff", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "stuff");
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -435,14 +435,14 @@ void add_contact_with_three_groups_update_removing_two(void **state)
     groups2 = g_slist_append(groups2, strdup("stuff"));
     roster_update("person@server.org", NULL, groups2, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 1);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 1);
 
-    GSList *found = g_slist_find_custom(groups_res, "stuff", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "stuff", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
     assert_string_equal(found->data, "stuff");
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -458,10 +458,10 @@ void add_contact_with_three_groups_update_removing_three(void **state)
 
     roster_update("person@server.org", NULL, NULL, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 0);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 0);
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -480,15 +480,15 @@ void add_contact_with_three_groups_update_two_new(void **state)
     groups2 = g_slist_append(groups2, strdup("somepeople"));
     roster_update("person@server.org", NULL, groups2, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 2);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 2);
 
-    GSList *found = g_slist_find_custom(groups_res, "newfriends", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "newfriends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "somepeople", g_strcmp0);
+    found = g_list_find_custom(groups_res, "somepeople", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -504,10 +504,10 @@ void add_remove_contact_groups(void **state)
 
     roster_remove("person@server.org", "person@server.org");
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 0);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 0);
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -526,21 +526,21 @@ void add_contacts_with_different_groups(void **state)
     groups2 = g_slist_append(groups2, strdup("somepeople"));
     roster_add("bob@server.org", NULL, groups2, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 5);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 5);
 
-    GSList *found = g_slist_find_custom(groups_res, "friends", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "friends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "work", g_strcmp0);
+    found = g_list_find_custom(groups_res, "work", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "stuff", g_strcmp0);
+    found = g_list_find_custom(groups_res, "stuff", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "newfriends", g_strcmp0);
+    found = g_list_find_custom(groups_res, "newfriends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "somepeople", g_strcmp0);
+    found = g_list_find_custom(groups_res, "somepeople", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -560,17 +560,17 @@ void add_contacts_with_same_groups(void **state)
     groups2 = g_slist_append(groups2, strdup("stuff"));
     roster_add("bob@server.org", NULL, groups2, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 3);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 3);
 
-    GSList *found = g_slist_find_custom(groups_res, "friends", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "friends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "work", g_strcmp0);
+    found = g_list_find_custom(groups_res, "work", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "stuff", g_strcmp0);
+    found = g_list_find_custom(groups_res, "stuff", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -590,19 +590,19 @@ void add_contacts_with_overlapping_groups(void **state)
     groups2 = g_slist_append(groups2, strdup("different"));
     roster_add("bob@server.org", NULL, groups2, NULL, FALSE);
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 4);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 4);
 
-    GSList *found = g_slist_find_custom(groups_res, "friends", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "friends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "work", g_strcmp0);
+    found = g_list_find_custom(groups_res, "work", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "stuff", g_strcmp0);
+    found = g_list_find_custom(groups_res, "stuff", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "different", g_strcmp0);
+    found = g_list_find_custom(groups_res, "different", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }
 
@@ -624,16 +624,16 @@ void remove_contact_with_remaining_in_group(void **state)
 
     roster_remove("bob@server.org", "bob@server.org");
 
-    GSList *groups_res = roster_get_groups();
-    assert_int_equal(g_slist_length(groups_res), 3);
+    GList *groups_res = roster_get_groups();
+    assert_int_equal(g_list_length(groups_res), 3);
 
-    GSList *found = g_slist_find_custom(groups_res, "friends", g_strcmp0);
+    GList *found = g_list_find_custom(groups_res, "friends", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "work", g_strcmp0);
+    found = g_list_find_custom(groups_res, "work", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
-    found = g_slist_find_custom(groups_res, "stuff", g_strcmp0);
+    found = g_list_find_custom(groups_res, "stuff", (GCompareFunc)g_strcmp0);
     assert_true(found != NULL);
 
-    g_slist_free_full(groups_res, g_free);
+    g_list_free_full(groups_res, free);
     roster_destroy();
 }

--- a/tests/unittests/test_server_events.c
+++ b/tests/unittests/test_server_events.c
@@ -13,6 +13,8 @@
 #include "ui/ui.h"
 #include "ui/stub_ui.h"
 #include "xmpp/muc.h"
+#include "plugins/plugins.h"
+#include "ui/window_list.h"
 
 void console_shows_online_presence_when_set_online(void **state)
 {

--- a/tests/unittests/tools/stub_http_upload.c
+++ b/tests/unittests/tools/stub_http_upload.c
@@ -21,9 +21,9 @@ typedef struct http_upload_t {
 
 //GSList *upload_processes;
 
-void* http_file_put(void *userdata) {}
+void* http_file_put(void *userdata) { return NULL; }
 
-char* file_mime_type(const char* const file_name) {}
-off_t file_size(const char* const file_name) {}
+char* file_mime_type(const char* const file_name) { return NULL; }
+off_t file_size(const char* const file_name) { return 0; }
 
 #endif

--- a/tests/unittests/unittests.c
+++ b/tests/unittests/unittests.c
@@ -52,8 +52,8 @@ int main(int argc, char* argv[]) {
     if (codeset) {
         printf("  CODESET:    %s\n", codeset);
     }
-    printf("  MB_CUR_MAX: %d\n", MB_CUR_MAX);
-    printf("  MB_LEN_MAX: %d\n", MB_LEN_MAX);
+    printf("  MB_CUR_MAX: %d\n", (int)MB_CUR_MAX);
+    printf("  MB_LEN_MAX: %d\n", (int)MB_LEN_MAX);
 
     const UnitTest all_tests[] = {
 


### PR DESCRIPTION
The flag hides errors. But we want unit tests to be correct in order
to reveal errors in the main code.

The patch removes tests_unittests_unittests_CFLAGS and makes autotools
use AM_CFLAGS instead. Therefore, unit tests are built with flags
derived from configure.ac.

@jubalh Please, take a look.