### PR TITLE
Fix optionnal sessionid in xep 0050

### DIFF
--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -1226,10 +1226,15 @@ _command_exec_response_handler(xmpp_stanza_t *const stanza, void *const userdata
             win_command_exec_error(win, command, "Unsupported command response");
             return 0;
         }
+        const char *sessionid = xmpp_stanza_get_attribute(cmd, "sessionid");
 
         DataForm *form = form_create(x);
         CommandConfigData *data = malloc(sizeof(CommandConfigData));
-        data->sessionid = strdup(xmpp_stanza_get_attribute(cmd, "sessionid"));
+        if (sessionid == NULL) {
+            data->sessionid = NULL;
+        } else {
+            data->sessionid = strdup(sessionid);
+        }
         data->command = command;
         ProfConfWin *confwin = (ProfConfWin*)wins_new_config(from, form, iq_submit_command_config, iq_cancel_command_config, data);
         confwin_handle_configuration(confwin, form);

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -2078,7 +2078,9 @@ stanza_create_command_config_submit_iq(xmpp_ctx_t *ctx, const char *const room,
     xmpp_stanza_set_name(command, STANZA_NAME_COMMAND);
     xmpp_stanza_set_ns(command, STANZA_NS_COMMAND);
     xmpp_stanza_set_attribute(command, "node", node);
-    xmpp_stanza_set_attribute(command, "sessionid", sessionid);
+    if (sessionid != NULL) {
+        xmpp_stanza_set_attribute(command, "sessionid", sessionid);
+    }
 
     xmpp_stanza_t *x = form_create_submission(form);
     xmpp_stanza_add_child(command, x);


### PR DESCRIPTION
sessionid appears to be optional in command messages.
Handle it correctly.