### PR TITLE
Change one of the `/help sub` examples to `/sub received`

### DIFF
--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -1009,7 +1009,7 @@ static struct cmd_t command_defs[] =
         CMD_EXAMPLES(
             "/sub request myfriend@jabber.org",
             "/sub allow myfriend@jabber.org",
-            "/sub request",
+            "/sub received",
             "/sub sent")
     },
 


### PR DESCRIPTION
`/sub request` doesn't work without a JID