### PR TITLE
Add random string at the end of the default resource

### DIFF
--- a/src/config/accounts.c
+++ b/src/config/accounts.c
@@ -124,16 +124,17 @@ accounts_add(const char *account_name, const char *altdomain, const int port, co
 {
     // set account name and resource
     const char *barejid = account_name;
-    const char *resource = "profanity";
+    char *resource = jid_random_resource();
     Jid *jid = jid_create(account_name);
     if (jid) {
         barejid = jid->barejid;
         if (jid->resourcepart) {
-            resource = jid->resourcepart;
+            resource = g_strdup(jid->resourcepart);
         }
     }
 
     if (g_key_file_has_group(accounts, account_name)) {
+        g_free(resource);
         jid_destroy(jid);
         return;
     }
@@ -174,6 +175,7 @@ accounts_add(const char *account_name, const char *altdomain, const int port, co
     autocomplete_add(enabled_ac, account_name);
 
     jid_destroy(jid);
+    g_free(resource);
 }
 
 int

--- a/src/xmpp/jid.c
+++ b/src/xmpp/jid.c
@@ -194,3 +194,22 @@ jid_fulljid_or_barejid(Jid *jid)
         return jid->barejid;
     }
 }
+
+char*
+jid_random_resource(void)
+{
+    GRand *prng;
+    char rand[5];
+    char alphabet[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    prng = g_rand_new();
+
+    int i;
+    for (i = 0; i < 4; i++) {
+        rand[i] = alphabet[g_rand_int_range(prng, 0, sizeof(alphabet))];
+    }
+    rand[4] = '\0';
+    g_rand_free(prng);
+
+    return g_strdup_printf("profanity.%s", rand);
+}

--- a/src/xmpp/jid.h
+++ b/src/xmpp/jid.h
@@ -57,5 +57,6 @@ char* create_fulljid(const char *const barejid, const char *const resource);
 char* get_nick_from_full_jid(const char *const full_room_jid);
 
 char* jid_fulljid_or_barejid(Jid *jid);
+char* jid_random_resource(void);
 
 #endif

--- a/src/xmpp/session.c
+++ b/src/xmpp/session.c
@@ -173,7 +173,9 @@ session_connect_with_details(const char *const jid, const char *const passwd, co
     Jid *jidp = jid_create(jid);
     if (jidp->resourcepart == NULL) {
         jid_destroy(jidp);
-        jidp = jid_create_from_bare_and_resource(jid, "profanity");
+        char *resource = jid_random_resource();
+        jidp = jid_create_from_bare_and_resource(jid, resource);
+        free(resource);
         saved_details.jid = strdup(jidp->fulljid);
     } else {
         saved_details.jid = strdup(jid);


### PR DESCRIPTION
When connecting for the first time or when creating a new account don't
use only 'profanity' as default resource.

Some server don't support having 2 connection with same resource. Using
profanity as default lead to deconnections.