### PR TITLE
Handle presence received before roster

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -115,6 +115,7 @@ sv_ev_roster_received(void)
         ui_show_roster();
     }
 
+    roster_process_pending_presence();
     char *account_name = session_get_account_name();
 
 #ifdef HAVE_LIBGPGME

--- a/src/xmpp/roster_list.h
+++ b/src/xmpp/roster_list.h
@@ -72,5 +72,6 @@ GSList* roster_get_contacts_by_presence(const char *const presence);
 char* roster_get_msg_display_name(const char *const barejid, const char *const resource);
 gint roster_compare_name(PContact a, PContact b);
 gint roster_compare_presence(PContact a, PContact b);
+void roster_process_pending_presence(void);
 
 #endif

--- a/tests/unittests/test_server_events.c
+++ b/tests/unittests/test_server_events.c
@@ -21,6 +21,7 @@ void console_shows_online_presence_when_set_online(void **state)
     prefs_set_string(PREF_STATUSES_CONSOLE, "online");
     plugins_init();
     roster_create();
+    roster_process_pending_presence();
     char *barejid = "test1@server";
     roster_add(barejid, "bob", NULL, "both", FALSE);
     Resource *resource = resource_new("resource", RESOURCE_ONLINE, NULL, 10);
@@ -40,6 +41,7 @@ void console_shows_online_presence_when_set_all(void **state)
     prefs_set_string(PREF_STATUSES_CONSOLE, "all");
     plugins_init();
     roster_create();
+    roster_process_pending_presence();
     char *barejid = "test1@server";
     roster_add(barejid, "bob", NULL, "both", FALSE);
     Resource *resource = resource_new("resource", RESOURCE_ONLINE, NULL, 10);
@@ -59,6 +61,7 @@ void console_shows_dnd_presence_when_set_all(void **state)
     prefs_set_string(PREF_STATUSES_CONSOLE, "all");
     plugins_init();
     roster_create();
+    roster_process_pending_presence();
     char *barejid = "test1@server";
     roster_add(barejid, "bob", NULL, "both", FALSE);
     Resource *resource = resource_new("resource", RESOURCE_ONLINE, NULL, 10);
@@ -77,6 +80,7 @@ void handle_offline_removes_chat_session(void **state)
 {
     plugins_init();
     roster_create();
+    roster_process_pending_presence();
     chat_sessions_init();
     char *barejid = "friend@server.chat.com";
     char *resource = "home";
@@ -100,6 +104,7 @@ void handle_offline_removes_chat_session(void **state)
 void lost_connection_clears_chat_sessions(void **state)
 {
     roster_create();
+    roster_process_pending_presence();
     chat_sessions_init();
     chat_session_recipient_active("bob@server.org", "laptop", FALSE);
     chat_session_recipient_active("steve@server.org", "mobile", FALSE);


### PR DESCRIPTION
Presence of contact not found in roster are filtered out.
But sometimes roster is received after a first few presences.

We choose to store presences until we receive roster and then process
this presences.

This should fix #1050 

Unit test are currently failing. Once fixed PR will be mergeable.