### PR TITLE
Add occupants wrap option

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -687,6 +687,7 @@ cmd_ac_init(void)
     autocomplete_add(occupants_ac, "size");
     autocomplete_add(occupants_ac, "indent");
     autocomplete_add(occupants_ac, "header");
+    autocomplete_add(occupants_ac, "wrap");
 
     occupants_default_ac = autocomplete_new();
     autocomplete_add(occupants_default_ac, "show");
@@ -2588,6 +2589,11 @@ _occupants_autocomplete(ProfWin *window, const char *const input, gboolean previ
     }
 
     found = autocomplete_param_with_ac(input, "/occupants header", occupants_header_ac, TRUE, previous);
+    if (found) {
+        return found;
+    }
+
+    found = autocomplete_param_with_func(input, "/occupants wrap", prefs_autocomplete_boolean_choice, previous);
     if (found) {
         return found;
     }

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -767,8 +767,8 @@ static struct cmd_t command_defs[] =
             { "default show|hide jid", "Whether occupants jids are shown by default in new rooms." },
             { "size <percent>",        "Percentage of the screen taken by the occupants list in rooms (1-99)." },
             { "indent <indent>",       "Indent contact line by <indent> spaces (0 to 10)." },
-            { "header char <char>",    "Prefix roster headers with specified character." },
-            { "header char none",      "Remove roster header character prefix." })
+            { "header char <char>",    "Prefix occupants headers with specified character." },
+            { "header char none",      "Remove occupants header character prefix." })
         CMD_NOEXAMPLES
     },
 

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -755,7 +755,8 @@ static struct cmd_t command_defs[] =
             "/occupants default show|hide [jid]",
             "/occupants size [<percent>]",
             "/occupants indent <indent>",
-            "/occupants header char <char>|none")
+            "/occupants header char <char>|none",
+            "/occupants wrap on|off")
         CMD_DESC(
             "Show or hide room occupants, and occupants panel display settings.")
         CMD_ARGS(
@@ -768,7 +769,8 @@ static struct cmd_t command_defs[] =
             { "size <percent>",        "Percentage of the screen taken by the occupants list in rooms (1-99)." },
             { "indent <indent>",       "Indent contact line by <indent> spaces (0 to 10)." },
             { "header char <char>",    "Prefix occupants headers with specified character." },
-            { "header char none",      "Remove occupants header character prefix." })
+            { "header char none",      "Remove occupants header character prefix." },
+            { "wrap on|off",           "Enable or disable line wrapping in occupants panel." })
         CMD_NOEXAMPLES
     },
 

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -4391,6 +4391,17 @@ cmd_occupants(ProfWin *window, const char *const command, gchar **args)
         }
     }
 
+    if (g_strcmp0(args[0], "wrap") == 0) {
+        if (!args[1]) {
+            cons_bad_cmd_usage(command);
+            return TRUE;
+        } else {
+            _cmd_set_boolean_preference(args[1], command, "Occupants panel line wrap", PREF_OCCUPANTS_WRAP);
+             occupantswin_occupants_all();
+            return TRUE;
+        }
+    }
+
     if (g_strcmp0(args[0], "default") == 0) {
         if (g_strcmp0(args[1], "show") == 0) {
             if (g_strcmp0(args[2], "jid") == 0) {

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -1641,6 +1641,7 @@ _get_group(preference_t pref)
         case PREF_HISTORY:
         case PREF_OCCUPANTS:
         case PREF_OCCUPANTS_JID:
+        case PREF_OCCUPANTS_WRAP:
         case PREF_STATUSES:
         case PREF_STATUSES_CONSOLE:
         case PREF_STATUSES_CHAT:
@@ -1788,6 +1789,8 @@ _get_key(preference_t pref)
             return "occupants";
         case PREF_OCCUPANTS_JID:
             return "occupants.jid";
+        case PREF_OCCUPANTS_WRAP:
+            return "occupants.wrap";
         case PREF_MUC_PRIVILEGES:
             return "privileges";
         case PREF_STATUSES:

--- a/src/config/preferences.h
+++ b/src/config/preferences.h
@@ -150,6 +150,7 @@ typedef enum {
     PREF_STATUSBAR_ROOM,
     PREF_OMEMO_LOG,
     PREF_OMEMO_POLICY,
+    PREF_OCCUPANTS_WRAP,
 } preference_t;
 
 typedef struct prof_alias_t {

--- a/src/config/theme.c
+++ b/src/config/theme.c
@@ -388,6 +388,7 @@ _load_preferences(void)
     _set_boolean_preference("resource.message", PREF_RESOURCE_MESSAGE);
     _set_boolean_preference("occupants", PREF_OCCUPANTS);
     _set_boolean_preference("occupants.jid", PREF_OCCUPANTS_JID);
+    _set_boolean_preference("occupants.wrap", PREF_OCCUPANTS_WRAP);
     _set_boolean_preference("roster", PREF_ROSTER);
     _set_boolean_preference("roster.offline", PREF_ROSTER_OFFLINE);
     _set_boolean_preference("roster.resource", PREF_ROSTER_RESOURCE);

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -1232,6 +1232,11 @@ cons_occupants_setting(void)
     else
         cons_show("Occupant jids (/occupants)          : hide");
 
+    if (prefs_get_boolean(PREF_OCCUPANTS_WRAP))
+        cons_show("Occupants wrap (/occupants)         : ON");
+    else
+        cons_show("Occupants wrap (/occupants)         : OFF");
+
     gint occupant_indent = prefs_get_occupants_indent();
     cons_show("Occupant indent (/occupants)        : %d", occupant_indent);
 

--- a/src/ui/occupantswin.c
+++ b/src/ui/occupantswin.c
@@ -58,22 +58,22 @@ _occuptantswin_occupant(ProfLayoutSplit *layout, Occupant *occupant, gboolean sh
         }
     }
 
-    GString *msg = g_string_new("");
-    g_string_append(msg, spaces->str);
+    GString *msg = g_string_new(spaces->str);
 
     gboolean wrap = prefs_get_boolean(PREF_OCCUPANTS_WRAP);
 
     g_string_append(msg, occupant->nick);
-    win_sub_print(layout->subwin, msg->str, TRUE, wrap, current_indent);
+    win_sub_newline_lazy(layout->subwin);
+    win_sub_print(layout->subwin, msg->str, FALSE, wrap, current_indent);
     g_string_free(msg, TRUE);
 
     if (showjid && occupant->jid) {
-        GString *msg = g_string_new("");
-        g_string_append(msg, spaces->str);
+        GString *msg = g_string_new(spaces->str);
         g_string_append(msg, " ");
 
         g_string_append(msg, occupant->jid);
-        win_sub_print(layout->subwin, msg->str, TRUE, wrap, current_indent);
+        win_sub_newline_lazy(layout->subwin);
+        win_sub_print(layout->subwin, msg->str, FALSE, wrap, current_indent);
         g_string_free(msg, TRUE);
     }
 

--- a/src/ui/occupantswin.c
+++ b/src/ui/occupantswin.c
@@ -49,7 +49,9 @@ _occuptantswin_occupant(ProfLayoutSplit *layout, Occupant *occupant, gboolean sh
     GString *spaces = g_string_new(" ");
 
     int indent = prefs_get_occupants_indent();
+    int current_indent = 0;
     if (indent > 0) {
+        current_indent += indent;
         while (indent > 0) {
             g_string_append(spaces, " ");
             indent--;
@@ -59,8 +61,10 @@ _occuptantswin_occupant(ProfLayoutSplit *layout, Occupant *occupant, gboolean sh
     GString *msg = g_string_new("");
     g_string_append(msg, spaces->str);
 
+    gboolean wrap = prefs_get_boolean(PREF_OCCUPANTS_WRAP);
+
     g_string_append(msg, occupant->nick);
-    win_sub_print(layout->subwin, msg->str, TRUE, FALSE, 0);
+    win_sub_print(layout->subwin, msg->str, TRUE, wrap, current_indent);
     g_string_free(msg, TRUE);
 
     if (showjid && occupant->jid) {
@@ -69,7 +73,7 @@ _occuptantswin_occupant(ProfLayoutSplit *layout, Occupant *occupant, gboolean sh
         g_string_append(msg, " ");
 
         g_string_append(msg, occupant->jid);
-        win_sub_print(layout->subwin, msg->str, TRUE, FALSE, 0);
+        win_sub_print(layout->subwin, msg->str, TRUE, wrap, current_indent);
         g_string_free(msg, TRUE);
     }
 


### PR DESCRIPTION
Wrapping for the occupants panel like already exists for the roster
panel. See `/occupants wrap on`.

Regards https://github.com/boothj5/profanity/issues/690